### PR TITLE
Fix bug with squared variables

### DIFF
--- a/tests/Sunset.Parser.Tests/Integration/Variable.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Integration/Variable.Tests.cs
@@ -139,6 +139,25 @@ public class VariableTests
         });
     }
 
+    [Test]
+    public void Analyse_SquaredVariable_CorrectResult()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               AirDensity <\rho> = 1.2 {kg / m^3}
+                                               WindSpeed <V_s> = 45 {m / s}
+                                               WindPressure <p> {kPa} = AirDensity * WindSpeed ^ 2
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+        Console.WriteLine(((FileScope)environment.ChildScopes["$file"]).PrintDefaultValues());
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"],
+            "WindPressure",
+            2.43,
+            DefinedUnits.Pascal,
+            ["AirDensity", "WindSpeed"]);
+    }
+
     private static void AssertVariableDeclaration(IScope scope, string variableName, double? expectedValue,
         Unit expectedUnit,
         string[]? referenceNames = null)


### PR DESCRIPTION
Added a test for squared variables in parser and markdown tests
Turns out the issue was with the LaTeX generation of squared variables
Fix #46