### PR TITLE
Remove unused Accept functions

### DIFF
--- a/src/Sunset.Parser/Scopes/Module.cs
+++ b/src/Sunset.Parser/Scopes/Module.cs
@@ -63,10 +63,4 @@ public class Module : IScope
     public required IScope? ParentScope { get; init; }
 
     public Dictionary<string, IPassData> PassData { get; } = [];
-
-    public T Accept<T>(IVisitor<T> visitor)
-    {
-        throw new NotImplementedException();
-    }
-
 }

--- a/src/Sunset.Parser/Visitors/Debugging/DebugPrinter.cs
+++ b/src/Sunset.Parser/Visitors/Debugging/DebugPrinter.cs
@@ -55,17 +55,17 @@ public class DebugPrinter(ErrorLog log) : IVisitor<string>
 
     private string Visit(BinaryExpression dest)
     {
-        return "(" + dest.OperatorToken + " " + dest.Left.Accept(this) + " " + dest.Right.Accept(this) + ")";
+        return "(" + dest.OperatorToken + " " + Visit(dest.Left) + " " + Visit(dest.Right) + ")";
     }
 
     private string Visit(UnaryExpression dest)
     {
-        return "(" + dest.OperatorToken + " " + dest.Operand.Accept(this) + ")";
+        return "(" + dest.OperatorToken + " " + Visit(dest.Operand) + ")";
     }
 
     private string Visit(GroupingExpression dest)
     {
-        return dest.InnerExpression.Accept(this);
+        return Visit(dest.InnerExpression);
     }
 
     private string Visit(NameExpression dest)
@@ -99,7 +99,8 @@ public class DebugPrinter(ErrorLog log) : IVisitor<string>
 
     private string Visit(UnitAssignmentExpression dest)
     {
-        return "(assign " + dest.Value.Accept(this) + " " + dest.UnitExpression.Accept(this) + ")";
+        if (dest.Value == null) return "(assign " + Visit(dest.UnitExpression) + ")";
+        return "(assign " + Visit(dest.Value) + " " + Visit(dest.UnitExpression) + ")";
     }
 
     private string Visit(CallExpression dest)

--- a/src/Sunset.Parser/Visitors/IVisitable.cs
+++ b/src/Sunset.Parser/Visitors/IVisitable.cs
@@ -11,15 +11,4 @@ public interface IVisitable
     ///     Dictionary of metadata that is stored within each node for each compiler or execution pass.
     /// </summary>
     public Dictionary<string, IPassData> PassData { get; }
-
-    /// <summary>
-    ///     Accepts a visitor to process the declaration.
-    /// </summary>
-    /// <param name="visitor">The <see cref="IVisitor{T}" /> that is being accepted.</param>
-    /// <typeparam name="T">The type that is being returned by the <see cref="INameResolver" />.</typeparam>
-    /// <returns>A value calculated by the <see cref="INameResolver" /></returns>
-    public T Accept<T>(IVisitor<T> visitor)
-    {
-        return visitor.Visit(this);
-    }
 }


### PR DESCRIPTION
Remove the unused `Accept` functions from `IVisitable`.

Due to the use of pattern matching within the main `Visit` functions, the indirection through `Accept` is no longer required.

Close #53 