### PR TITLE
Fix if expression printing redundant value expression for constants

### DIFF
--- a/src/Sunset.Reporting/VariablePrinterBase.cs
+++ b/src/Sunset.Reporting/VariablePrinterBase.cs
@@ -103,9 +103,22 @@ public abstract class VariablePrinterBase(PrinterSettings settings, EquationComp
 
                         break;
                     }
-                    case IfExpression:
-                        result += eq.AlignEquals + ReportValueExpression(evaluationTarget, currentScope) + eq.Newline;
+                    case IfExpression ifExpression:
+                    {
+                        // Only print the value expression if the evaluated branch body has references
+                        // or is a binary expression (which would show the calculation with values substituted).
+                        // Skip for simple constants to avoid redundant output like "= 15 \\ = 15".
+                        if (ifExpression.GetResult(currentScope) is BranchResult branchResult)
+                        {
+                            var branchBody = branchResult.Result.Body;
+                            var branchReferences = branchBody.GetReferences();
+                            if (branchReferences?.Count > 0 || branchBody is BinaryExpression)
+                            {
+                                result += eq.AlignEquals + ReportValueExpression(evaluationTarget, currentScope) + eq.Newline;
+                            }
+                        }
                         break;
+                    }
                 }
 
                 result += eq.AlignEquals + ReportValue(evaluationTarget, currentScope) + eq.Linebreak;


### PR DESCRIPTION
## Summary
- When an if expression evaluates to a simple constant value (like `15`), the value expression was being printed even though it would be identical to the final result
- Now we only print the value expression if the evaluated branch body has references to other variables OR is a binary expression that would show calculation with values substituted
- Added regression test to verify the fix

Fixes #45

## Test plan
- [x] All existing tests pass (204 tests)
- [x] Added new test `PrintDefaultValues_IfExpressionWithConstant_NoRedundantValueExpression` to verify the fix

🤖 Generated with [Claude Code](https://claude.ai/code)