### PR TITLE
Fix large integer parsing causing overflow exception

### DIFF
--- a/src/Sunset.Parser/Lexing/Lexer.cs
+++ b/src/Sunset.Parser/Lexing/Lexer.cs
@@ -365,7 +365,15 @@ public class Lexer
                 start, _position, _line, _column, _file);
         }
 
-        return new IntToken(int.Parse(_source[start.._position].Span), start, _position, _line, _column, _file);
+        // Try to parse as int first, fall back to double for large numbers (fixes issue #71)
+        var numberSpan = _source[start.._position].Span;
+        if (int.TryParse(numberSpan, out var intValue))
+        {
+            return new IntToken(intValue, start, _position, _line, _column, _file);
+        }
+
+        // Number is too large for int, parse as double instead
+        return new DoubleToken(double.Parse(numberSpan), start, _position, _line, _column, _file);
     }
 
     /// <summary>

--- a/tests/Sunset.Parser.Tests/Lexer/Lexer.SingleToken.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Lexer/Lexer.SingleToken.Tests.cs
@@ -112,6 +112,45 @@ public class LexerSingleTokenTests
         lex.Log.PrintLogToConsole();
     }
 
+    /// <summary>
+    /// Regression test for issue #71: Large values should not truncate.
+    /// Numbers larger than int.MaxValue should be parsed as doubles.
+    /// </summary>
+    [Test]
+    public void GetNextToken_LargeInteger_ParsesAsDouble()
+    {
+        // 10 billion - larger than int.MaxValue (2,147,483,647)
+        var lex = new Lexing.Lexer(SourceFile.FromString("10000000000"), false);
+        var token = lex.GetNextToken();
+        Assert.That(token.Type, Is.EqualTo(TokenType.Number));
+        if (token is DoubleToken doubleToken)
+        {
+            Assert.That(doubleToken.Value, Is.EqualTo(10000000000.0));
+            return;
+        }
+
+        Assert.Fail("Large integer should be parsed as DoubleToken, not IntToken");
+    }
+
+    /// <summary>
+    /// Regression test for issue #71: Very large values should not truncate.
+    /// </summary>
+    [Test]
+    public void GetNextToken_VeryLargeInteger_ParsesCorrectly()
+    {
+        // 1 followed by 20 zeros - a very large number
+        var lex = new Lexing.Lexer(SourceFile.FromString("100000000000000000000"), false);
+        var token = lex.GetNextToken();
+        Assert.That(token.Type, Is.EqualTo(TokenType.Number));
+        if (token is DoubleToken doubleToken)
+        {
+            Assert.That(doubleToken.Value, Is.EqualTo(1e20));
+            return;
+        }
+
+        Assert.Fail("Very large integer should be parsed as DoubleToken");
+    }
+
     [Test]
     public void GetNextToken_SingleLineString_HasCorrectValue()
     {


### PR DESCRIPTION
## Summary
- Fixed lexer crash when parsing large integer literals (> int.MaxValue)
- Previously `int.Parse` would throw `OverflowException` for numbers like 10000000000
- Now uses `int.TryParse` with fallback to `double` for large numbers
- Added regression tests for large integer parsing

Fixes #71

## Test plan
- [x] All existing tests pass (205 tests)
- [x] Added test `GetNextToken_LargeInteger_ParsesAsDouble` - 10 billion parsed correctly
- [x] Added test `GetNextToken_VeryLargeInteger_ParsesCorrectly` - 1e20 parsed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)