### PR TITLE
feat: implement non-dimensionalizing units syntax {/ unit}

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,13 +121,13 @@ All core mathematical functions have been implemented in the `src/Sunset.Parser/
 ## Priority 3: Unit Operations
 
 ### Non-dimensionalising Units
-**Status:** ⬜ Not Started
+**Status:** ✅ Implemented
 
 Allows removing units from a quantity by dividing by a specified unit, returning a dimensionless numeric value.
 
 | Feature | Syntax | Status |
 |---------|--------|--------|
-| Unit removal | `quantity {/ unit}` | ⬜ |
+| Unit removal | `quantity {/ unit}` | ✅ |
 
 **Syntax:**
 ```sunset
@@ -145,11 +145,12 @@ Result = (50 {cm}) {/ m}  // Results in 0.5 (dimensionless)
 - **Compile-time error** if the units are not dimensionally compatible (e.g., trying to non-dimensionalise `{m}` with `{s}`)
 - Error should not block execution of other unrelated code in the AST
 
-**Implementation Notes:**
-- Add new unit expression syntax `{/ unit}` to lexer
-- Implement dimensional compatibility check in TypeChecker
-- Add `DimensionalIncompatibilityError` to semantic errors
-- Evaluator should convert to target units, then strip units from result
+**Implementation Details:**
+- `NonDimensionalizingExpression` class in `src/Sunset.Parser/Expressions/NonDimensionalizingExpression.cs`
+- Parser detects `{/` pattern in `Parser.Rules.cs` and creates `NonDimensionalizingExpression`
+- `DimensionalIncompatibilityError` in `src/Sunset.Parser/Errors/Semantic/DimensionalIncompatibilityError.cs`
+- TypeChecker validates dimensional compatibility
+- Evaluator converts the value to the target unit and returns a dimensionless result
 
 ---
 
@@ -400,7 +401,7 @@ The following bugs have been fixed:
 | Logical Operators | 3 | 0 | 1 | 2 |
 | Lists - Basic | 4 | 4 | 0 | 0 |
 | Lists - Advanced | 6 | 6 | 0 | 0 |
-| Unit Operations | 1 | 0 | 0 | 1 |
+| Unit Operations | 1 | 1 | 0 | 0 |
 | String Operations | 4 | 0 | 0 | 4 |
 | Functional Programming | 5 | 0 | 0 | 5 |
 | Dictionaries | 7 | 6 | 0 | 1 |
@@ -408,7 +409,7 @@ The following bugs have been fixed:
 | Element Inheritance | 5 | 1 | 0 | 4 |
 | Anonymous Elements | 2 | 0 | 0 | 2 |
 | Element Groups | 2 | 0 | 0 | 2 |
-| **Total** | **49** | **24** | **1** | **24** |
+| **Total** | **49** | **25** | **1** | **23** |
 
 ---
 

--- a/src/Sunset.Parser/Analysis/NameResolution/NameResolver.cs
+++ b/src/Sunset.Parser/Analysis/NameResolution/NameResolver.cs
@@ -1,4 +1,4 @@
-﻿using Sunset.Parser.BuiltIns;
+using Sunset.Parser.BuiltIns;
 using Sunset.Parser.BuiltIns.ListMethods;
 using Sunset.Parser.Errors;
 using Sunset.Parser.Errors.Semantic;
@@ -57,6 +57,9 @@ public class NameResolver(ErrorLog log) : INameResolver
                 break;
             case UnitAssignmentExpression unitAssignmentExpression:
                 Visit(unitAssignmentExpression, parentScope);
+                break;
+            case NonDimensionalizingExpression nonDimensionalizingExpression:
+                Visit(nonDimensionalizingExpression, parentScope);
                 break;
             case ListExpression listExpression:
                 Visit(listExpression, parentScope);
@@ -147,6 +150,14 @@ public class NameResolver(ErrorLog log) : INameResolver
     private void Visit(UnitAssignmentExpression dest, IScope parentScope)
     {
         // Resolve names in the unit expression (e.g., kg, m, s in {kg m / s^2})
+        Visit(dest.UnitExpression, parentScope);
+    }
+
+    private void Visit(NonDimensionalizingExpression dest, IScope parentScope)
+    {
+        // Resolve names in the value expression
+        Visit(dest.Value, parentScope);
+        // Resolve names in the unit expression
         Visit(dest.UnitExpression, parentScope);
     }
 

--- a/src/Sunset.Parser/Analysis/ReferenceChecking/ReferenceChecker.cs
+++ b/src/Sunset.Parser/Analysis/ReferenceChecking/ReferenceChecker.cs
@@ -1,4 +1,4 @@
-﻿using Sunset.Parser.Analysis.NameResolution;
+using Sunset.Parser.Analysis.NameResolution;
 using Sunset.Parser.Errors;
 using Sunset.Parser.Errors.Semantic;
 using Sunset.Parser.Expressions;
@@ -46,6 +46,7 @@ public class ReferenceChecker(ErrorLog log)
             IScope scope => Visit(scope, visited),
             IConstant => null,
             UnitAssignmentExpression unitAssignmentExpression => Visit(unitAssignmentExpression, visited),
+            NonDimensionalizingExpression nonDimensionalizingExpression => Visit(nonDimensionalizingExpression, visited),
             ListExpression listExpression => Visit(listExpression, visited),
             DictionaryExpression dictionaryExpression => Visit(dictionaryExpression, visited),
             IndexExpression indexExpression => Visit(indexExpression, visited),
@@ -102,6 +103,12 @@ public class ReferenceChecker(ErrorLog log)
     private HashSet<IDeclaration>? Visit(UnitAssignmentExpression dest, HashSet<IDeclaration> visited)
     {
         return null;
+    }
+
+    private HashSet<IDeclaration>? Visit(NonDimensionalizingExpression dest, HashSet<IDeclaration> visited)
+    {
+        // Get references from the value expression (the unit expression doesn't create references)
+        return Visit(dest.Value, visited);
     }
 
     private HashSet<IDeclaration>? Visit(UnitDeclaration dest, HashSet<IDeclaration> visited)

--- a/src/Sunset.Parser/Errors/Semantic/DimensionalIncompatibilityError.cs
+++ b/src/Sunset.Parser/Errors/Semantic/DimensionalIncompatibilityError.cs
@@ -1,0 +1,28 @@
+using Sunset.Parser.Analysis.TypeChecking;
+using Sunset.Parser.Expressions;
+using Sunset.Parser.Lexing.Tokens;
+
+namespace Sunset.Parser.Errors.Semantic;
+
+/// <summary>
+/// Error when attempting to non-dimensionalize a quantity with an incompatible unit.
+/// For example, trying to non-dimensionalize a length {m} with a time unit {s}.
+/// </summary>
+public class DimensionalIncompatibilityError(NonDimensionalizingExpression expression) : ISemanticError
+{
+    public string Message
+    {
+        get
+        {
+            var valueType = expression.Value.GetEvaluatedType();
+            var unitType = expression.UnitExpression.GetEvaluatedType();
+            return
+                $"Cannot non-dimensionalize: the value has units {{{valueType}}} but the divisor has units {{{unitType}}}. " +
+                $"The dimensions must be compatible.";
+        }
+    }
+
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken StartToken { get; } = expression.DivideToken;
+    public IToken? EndToken => expression.Close;
+}

--- a/src/Sunset.Parser/Expressions/NonDimensionalizingExpression.cs
+++ b/src/Sunset.Parser/Expressions/NonDimensionalizingExpression.cs
@@ -1,0 +1,68 @@
+using Sunset.Parser.Analysis.TypeChecking;
+using Sunset.Parser.Lexing.Tokens;
+using Sunset.Quantities.Units;
+
+namespace Sunset.Parser.Expressions;
+
+/// <summary>
+/// An expression that removes units from a quantity by dividing by a specified unit,
+/// returning a dimensionless numeric value.
+/// </summary>
+/// <remarks>
+/// Syntax: <c>quantity {/ unit}</c>
+/// Example: <c>Length = 100 {mm}; NumericValue = Length {/ m}</c> results in 0.1 (dimensionless)
+/// </remarks>
+public class NonDimensionalizingExpression : ExpressionBase
+{
+    /// <summary>
+    /// Creates a non-dimensionalizing expression.
+    /// </summary>
+    /// <param name="open">The opening brace token.</param>
+    /// <param name="divideToken">The divide (/) token.</param>
+    /// <param name="close">The closing brace token.</param>
+    /// <param name="value">The expression whose units are being removed.</param>
+    /// <param name="unitExpression">The unit expression to divide by.</param>
+    public NonDimensionalizingExpression(
+        IToken open,
+        IToken divideToken,
+        IToken? close,
+        IExpression value,
+        IExpression unitExpression)
+    {
+        Open = open;
+        DivideToken = divideToken;
+        Close = close;
+        Value = value;
+        UnitExpression = unitExpression;
+    }
+
+    /// <summary>
+    /// The opening brace token.
+    /// </summary>
+    public IToken Open { get; }
+
+    /// <summary>
+    /// The divide (/) token within the braces.
+    /// </summary>
+    public IToken DivideToken { get; }
+
+    /// <summary>
+    /// The closing brace token.
+    /// </summary>
+    public IToken? Close { get; }
+
+    /// <summary>
+    /// The expression whose units are being removed.
+    /// </summary>
+    public IExpression Value { get; }
+
+    /// <summary>
+    /// The unit expression to divide by.
+    /// </summary>
+    public IExpression UnitExpression { get; }
+
+    /// <summary>
+    /// Gets the resolved unit from type checking, if available.
+    /// </summary>
+    public Unit? Unit => this.GetEvaluatedUnit();
+}

--- a/tests/Sunset.Parser.Tests/Integration/NonDimensionalizing.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Integration/NonDimensionalizing.Tests.cs
@@ -1,0 +1,164 @@
+using Sunset.Parser.Errors;
+using Sunset.Parser.Errors.Semantic;
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Results;
+using Sunset.Parser.Scopes;
+using Sunset.Parser.Visitors.Evaluation;
+using Sunset.Quantities.Units;
+using Environment = Sunset.Parser.Scopes.Environment;
+
+namespace Sunset.Parser.Test.Integration;
+
+[TestFixture]
+public class NonDimensionalizingTests
+{
+    [Test]
+    public void Analyse_NonDimensionalize_SameUnit_ReturnsValue()
+    {
+        // Length = 100 {mm}, NumericValue = Length {/ m} => 0.1 (100 mm = 0.1 m)
+        var sourceFile = SourceFile.FromString("""
+                                               Length {m} = 100 {mm}
+                                               NumericValue = Length {/ m}
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Length", 0.1, DefinedUnits.Metre);
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "NumericValue", 0.1, DefinedUnits.Dimensionless);
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_NonDimensionalize_DifferentUnitSameDimension_ReturnsConvertedValue()
+    {
+        // 500 mm expressed in metres = 0.5
+        var sourceFile = SourceFile.FromString("""
+                                               Length {mm} = 500 {mm}
+                                               NumericValue = Length {/ m}
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Length", 500, DefinedUnits.Millimetre);
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "NumericValue", 0.5, DefinedUnits.Dimensionless);
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_NonDimensionalize_IncompatibleDimensions_ReturnsError()
+    {
+        // Trying to non-dimensionalize length (m) with time (s) should fail
+        var sourceFile = SourceFile.FromString("""
+                                               Length {m} = 100 {m}
+                                               NumericValue = Length {/ s}
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.True);
+        Assert.That(environment.Log.Errors.Any(e => e is DimensionalIncompatibilityError), Is.True);
+    }
+
+    [Test]
+    public void Analyse_NonDimensionalize_InlineExpression_Works()
+    {
+        // (500 {mm}) {/ m} = 0.5
+        var sourceFile = SourceFile.FromString("""
+                                               Result = (500 {mm}) {/ m}
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Result", 0.5, DefinedUnits.Dimensionless);
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_NonDimensionalize_ComplexUnit_Works()
+    {
+        // Area in mm^2 expressed in m^2
+        var sourceFile = SourceFile.FromString("""
+                                               Area {mm^2} = 1000000 {mm^2}
+                                               NumericValue = Area {/ m^2}
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Area", 1000000, DefinedUnits.Millimetre * DefinedUnits.Millimetre);
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "NumericValue", 1, DefinedUnits.Dimensionless);
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_NonDimensionalize_UsedInCalculation_Works()
+    {
+        // Non-dimensionalized value can be used in further calculations
+        var sourceFile = SourceFile.FromString("""
+                                               Length {m} = 2 {m}
+                                               NumericValue = Length {/ m}
+                                               DoubledValue = NumericValue * 2
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Length", 2, DefinedUnits.Metre);
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "NumericValue", 2, DefinedUnits.Dimensionless);
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "DoubledValue", 4, DefinedUnits.Dimensionless);
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_NonDimensionalize_DifferentScale_Works()
+    {
+        // Length in km expressed in metres = 1000
+        var sourceFile = SourceFile.FromString("""
+                                               Length {km} = 1 {km}
+                                               NumericValue = Length {/ m}
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        // 1 km = 1000 m, so NumericValue should be 1000
+        AssertVariableDeclarationApprox(environment.ChildScopes["$file"], "NumericValue", 1000, DefinedUnits.Dimensionless, 0.001);
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    private static void AssertVariableDeclarationApprox(IScope scope, string variableName, double expectedValue, Unit expectedUnit, double tolerance)
+    {
+        if (scope.ChildDeclarations[variableName] is VariableDeclaration variableDeclaration)
+        {
+            var value = variableDeclaration.GetResult(scope);
+
+            Assert.That(value, Is.Not.Null);
+            Assert.That(value, Is.InstanceOf<QuantityResult>());
+
+            var quantityResult = (QuantityResult)value!;
+            Assert.That(quantityResult.Result.BaseValue, Is.EqualTo(expectedValue).Within(tolerance));
+            Assert.That(Unit.EqualDimensions(quantityResult.Result.Unit, expectedUnit), Is.True);
+        }
+        else
+        {
+            Assert.Fail($"Expected variable {variableName} to be declared.");
+        }
+    }
+
+    private static void AssertVariableDeclaration(IScope scope, string variableName, double expectedValue, Unit expectedUnit)
+    {
+        AssertVariableDeclaration(scope, variableName, new QuantityResult(expectedValue, expectedUnit));
+    }
+
+    private static void AssertVariableDeclaration(IScope scope, string variableName, IResult expectedValue)
+    {
+        if (scope.ChildDeclarations[variableName] is VariableDeclaration variableDeclaration)
+        {
+            var value = variableDeclaration.GetResult(scope);
+
+            Assert.That(value, Is.Not.Null);
+            Assert.That(value, Is.EqualTo(expectedValue));
+        }
+        else
+        {
+            Assert.Fail($"Expected variable {variableName} to be declared.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `{/ unit}` syntax to remove units from a quantity and return a dimensionless numeric value
- Implements Priority 3 from the ROADMAP

## Changes
- `NonDimensionalizingExpression` for AST representation
- Parser support for `{/ unit}` syntax in `Parser.Rules.cs`
- `DimensionalIncompatibilityError` for incompatible unit dimensions
- Type checking to validate dimensional compatibility
- Evaluator to compute the dimensionless result
- Name resolution and reference checking support
- Comprehensive test coverage (7 tests)

## Example Usage
```sunset
Length = 100 {mm}
NumericValue = Length {/ m}  // Results in 0.1 (dimensionless)

// Works inline too
Result = (500 {mm}) {/ m}  // Results in 0.5 (dimensionless)
```

## Test Results
All 267 tests pass including 7 new tests for non-dimensionalizing units.