### PR TITLE
feat: implement string operations (Priority 4)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,13 +121,13 @@ All core mathematical functions have been implemented in the `src/Sunset.Parser/
 ## Priority 3: Unit Operations
 
 ### Non-dimensionalising Units
-**Status:** ⬜ Not Started
+**Status:** ✅ Implemented
 
 Allows removing units from a quantity by dividing by a specified unit, returning a dimensionless numeric value.
 
 | Feature | Syntax | Status |
 |---------|--------|--------|
-| Unit removal | `quantity {/ unit}` | ⬜ |
+| Unit removal | `quantity {/ unit}` | ✅ |
 
 **Syntax:**
 ```sunset
@@ -156,57 +156,44 @@ Result = (50 {cm}) {/ m}  // Results in 0.5 (dimensionless)
 ## Priority 4: String Operations
 
 ### String Concatenation
-**Status:** ⬜ Not Started
+**Status:** ✅ Implemented
 
 | Feature | Syntax | Status |
 |---------|--------|--------|
-| String + String | `"hello " + "world"` | ⬜ |
-| String + Quantity | `"Length: " + 100 {mm}` | ⬜ |
+| String + String | `"hello " + "world"` | ✅ |
+| String + Quantity | `"Length: " + 100 {mm}` | ✅ |
+| Quantity + String | `100 {mm} + " long"` | ✅ |
 
 **Behavior:**
 - Concatenating two strings produces a combined string
 - Concatenating a string with a quantity uses the display format with units (e.g., `"100 mm"`)
+- Dimensionless quantities omit the unit in the formatted output
 
-**Implementation Notes:**
-- Extend binary expression handling for `+` operator with string operands
-- Add `StringResult` type if not already present
-- Implement quantity-to-string conversion using existing display formatting
+**Implementation Details:**
+- Type checking in `TypeChecker.cs` handles string+string, string+quantity, and quantity+string cases
+- Evaluation in `Evaluator.cs` performs concatenation with `FormatQuantity()` helper
+- `StringResult` equality implemented for proper value comparison
+- `StringType` added as a valid type that doesn't require unit declarations
 
 ---
 
 ### String Interpolation
-**Status:** ⬜ Not Started
+**Status:** ⬜ Not Started (Deferred)
 
 | Feature | Syntax | Status |
 |---------|--------|--------|
 | Interpolation | `"Depth {expression}"` | ⬜ |
 
-**Syntax:**
-```sunset
-Length = 100 {mm}
-Message = "The length is {Length}"  // Results in "The length is 100 mm"
-
-// Inline expressions
-Summary = "Area: {Width * Height}"
-```
-
-**Behavior:**
-- Expressions within `{...}` inside a string are evaluated and converted to their display format
-- Quantities include their units in the interpolated output
-
-**Implementation Notes:**
-- Modify lexer to handle interpolation tokens within strings
-- Add `InterpolatedStringExpression` to parse interpolated segments
-- Evaluate each segment and concatenate results
+**Note:** String interpolation is deferred due to syntax conflict with the `{unit}` notation used for unit assignments. The `{` character inside strings cannot easily be distinguished from the start of a unit assignment expression without significant lexer changes. Use string concatenation as an alternative.
 
 ---
 
 ### List Join Method
-**Status:** ⬜ Not Started
+**Status:** ✅ Implemented
 
 | Feature | Syntax | Status |
 |---------|--------|--------|
-| Join strings | `list.join(separator)` | ⬜ |
+| Join strings | `list.join(separator)` | ✅ |
 
 **Syntax:**
 ```sunset
@@ -217,11 +204,13 @@ Sentence = Words.join(", ")  // Results in "hello, world"
 **Behavior:**
 - Joins a list of strings using the specified separator
 - Returns a single concatenated string
+- Empty lists return an empty string
+- Single-element lists return the element without separator
 
-**Implementation Notes:**
-- Add `JoinMethod` to `src/Sunset.Parser/BuiltIns/ListMethods/`
-- Type check that the list contains strings and separator is a string
-- Implement in evaluator using standard string join logic
+**Implementation Details:**
+- `JoinMethod` in `src/Sunset.Parser/BuiltIns/ListMethods/JoinMethod.cs`
+- `IListMethodWithStringArgument` interface for methods taking string arguments
+- Type checking validates list elements and separator are strings
 
 ---
 
@@ -400,15 +389,15 @@ The following bugs have been fixed:
 | Logical Operators | 3 | 0 | 1 | 2 |
 | Lists - Basic | 4 | 4 | 0 | 0 |
 | Lists - Advanced | 6 | 6 | 0 | 0 |
-| Unit Operations | 1 | 0 | 0 | 1 |
-| String Operations | 4 | 0 | 0 | 4 |
+| Unit Operations | 1 | 1 | 0 | 0 |
+| String Operations | 4 | 3 | 0 | 1 |
 | Functional Programming | 5 | 0 | 0 | 5 |
 | Dictionaries | 7 | 6 | 0 | 1 |
 | Options | 3 | 0 | 0 | 3 |
 | Element Inheritance | 5 | 1 | 0 | 4 |
 | Anonymous Elements | 2 | 0 | 0 | 2 |
 | Element Groups | 2 | 0 | 0 | 2 |
-| **Total** | **49** | **24** | **1** | **24** |
+| **Total** | **49** | **28** | **1** | **20** |
 
 ---
 

--- a/src/Sunset.Parser/Analysis/TypeChecking/TypeChecker.cs
+++ b/src/Sunset.Parser/Analysis/TypeChecking/TypeChecker.cs
@@ -140,6 +140,36 @@ public class TypeChecker(ErrorLog log) : IVisitor<IResultType?>
                 var resultUnit = BinaryUnitOperation(dest, leftQuantityType.Unit, rightUnitType.Unit);
                 return resultUnit == null ? null : new QuantityType(resultUnit);
             }
+            // String concatenation: string + string
+            case StringType when rightResult is StringType:
+            {
+                if (dest.Operator == TokenType.Plus)
+                {
+                    return StringType.Instance;
+                }
+                Log.Error(new InvalidStringOperationError(dest));
+                return ErrorValueType.Instance;
+            }
+            // String concatenation: string + quantity
+            case StringType when rightResult is QuantityType:
+            {
+                if (dest.Operator == TokenType.Plus)
+                {
+                    return StringType.Instance;
+                }
+                Log.Error(new InvalidStringOperationError(dest));
+                return ErrorValueType.Instance;
+            }
+            // String concatenation: quantity + string
+            case QuantityType when rightResult is StringType:
+            {
+                if (dest.Operator == TokenType.Plus)
+                {
+                    return StringType.Instance;
+                }
+                Log.Error(new InvalidStringOperationError(dest));
+                return ErrorValueType.Instance;
+            }
             default:
                 throw new NotImplementedException($"Binary expression type checking not implemented for left: {leftResult.GetType()}, right: {rightResult.GetType()}");
         }
@@ -433,6 +463,35 @@ public class TypeChecker(ErrorLog log) : IVisitor<IResultType?>
             return resultType;
         }
 
+        // For methods with string arguments (join)
+        if (method is IListMethodWithStringArgument methodWithStringArg)
+        {
+            if (dest.Arguments.Count == 0)
+            {
+                Log.Error(new ListMethodMissingArgumentError(dest, method.Name));
+                return ErrorValueType.Instance;
+            }
+
+            // Type check the argument
+            var argType = Visit(dest.Arguments[0].Expression);
+            if (argType == null || argType is ErrorValueType)
+            {
+                return ErrorValueType.Instance;
+            }
+
+            // For 'join', check that the separator argument is a string
+            if (method is JoinMethod && argType is not StringType)
+            {
+                Log.Error(new ListMethodWrongArgumentTypeError(dest, method.Name, "string"));
+                return ErrorValueType.Instance;
+            }
+
+            // Determine result type
+            var resultType = methodWithStringArg.GetResultType(listType, argType);
+            dest.SetEvaluatedType(resultType);
+            return resultType;
+        }
+
         // Determine the result type using the method's own logic
         var simpleResultType = method.GetResultType(listType);
         dest.SetEvaluatedType(simpleResultType);
@@ -463,10 +522,9 @@ public class TypeChecker(ErrorLog log) : IVisitor<IResultType?>
         return propertyType;
     }
 
-    private IResultType? Visit(StringConstant dest)
+    private static IResultType Visit(StringConstant dest)
     {
-        Log.Error(new StringInExpressionError(dest.Token));
-        return null;
+        return StringType.Instance;
     }
 
     private static IResultType Visit(UnitConstant dest)
@@ -752,6 +810,18 @@ public class TypeChecker(ErrorLog log) : IVisitor<IResultType?>
                     return evaluatedType;
                 // Note that it is OK to not assign a unit to a variable with a dimensionless or angle result.
                 case QuantityType quantityType when quantityType.Unit.IsDimensionless || Unit.EqualDimensions(quantityType.Unit, DefinedUnits.Radian):
+                    dest.SetAssignedType(evaluatedType);
+                    return evaluatedType;
+                // Strings don't require unit declarations
+                case StringType:
+                    dest.SetAssignedType(evaluatedType);
+                    return evaluatedType;
+                // Boolean results don't require unit declarations
+                case BooleanType:
+                    dest.SetAssignedType(evaluatedType);
+                    return evaluatedType;
+                // Lists don't require unit declarations (their element types are validated separately)
+                case ListType:
                     dest.SetAssignedType(evaluatedType);
                     return evaluatedType;
             }

--- a/src/Sunset.Parser/BuiltIns/ListMethods/JoinMethod.cs
+++ b/src/Sunset.Parser/BuiltIns/ListMethods/JoinMethod.cs
@@ -1,0 +1,83 @@
+using Sunset.Parser.Expressions;
+using Sunset.Parser.Results;
+using Sunset.Parser.Results.Types;
+using Sunset.Parser.Scopes;
+
+namespace Sunset.Parser.BuiltIns.ListMethods;
+
+/// <summary>
+/// Joins elements of a string list with a separator.
+/// Syntax: list.join(separator)
+/// Example: ["hello", "world"].join(", ") returns "hello, world"
+/// </summary>
+public class JoinMethod : IListMethodWithStringArgument
+{
+    public static JoinMethod Instance { get; } = new();
+
+    public string Name => "join";
+
+    public IResultType GetResultType(ListType listType)
+    {
+        // join always returns a string
+        return StringType.Instance;
+    }
+
+    public IResultType GetResultType(ListType listType, IResultType argumentType)
+    {
+        // join always returns a string
+        return StringType.Instance;
+    }
+
+    public IResult Evaluate(ListResult list)
+    {
+        // Default join with empty separator
+        return Evaluate(list, "");
+    }
+
+    public IResult Evaluate(ListResult list, string separator)
+    {
+        if (list.Count == 0)
+        {
+            return new StringResult("");
+        }
+
+        var strings = new List<string>();
+        foreach (var item in list.Elements)
+        {
+            switch (item)
+            {
+                case StringResult stringResult:
+                    strings.Add(stringResult.Result);
+                    break;
+                case QuantityResult quantityResult:
+                    // Format quantity with its display value and units
+                    var qty = quantityResult.Result;
+                    var value = qty.ConvertedValue;
+                    var unit = qty.Unit.IsDimensionless ? "" : " " + qty.Unit;
+                    strings.Add(value + unit);
+                    break;
+                default:
+                    strings.Add(item.ToString() ?? "");
+                    break;
+            }
+        }
+
+        return new StringResult(string.Join(separator, strings));
+    }
+}
+
+/// <summary>
+/// Interface for list methods that take a string argument (like join).
+/// </summary>
+public interface IListMethodWithStringArgument : IListMethod
+{
+    /// <summary>
+    /// Determines the result type given the list type and the argument type.
+    /// </summary>
+    IResultType GetResultType(ListType listType, IResultType argumentType);
+
+    /// <summary>
+    /// Evaluates the method on the given list with a string argument.
+    /// </summary>
+    IResult Evaluate(ListResult list, string separator);
+}

--- a/src/Sunset.Parser/BuiltIns/ListMethods/ListMethods.cs
+++ b/src/Sunset.Parser/BuiltIns/ListMethods/ListMethods.cs
@@ -16,6 +16,7 @@ public static class ListMethods
         ["foreach"] = ForEachMethod.Instance,
         ["where"] = WhereMethod.Instance,
         ["select"] = SelectMethod.Instance,
+        ["join"] = JoinMethod.Instance,
     };
 
     /// <summary>

--- a/src/Sunset.Parser/Errors/Semantic/StringErrors.cs
+++ b/src/Sunset.Parser/Errors/Semantic/StringErrors.cs
@@ -1,0 +1,18 @@
+using Sunset.Parser.Expressions;
+using Sunset.Parser.Lexing.Tokens;
+
+namespace Sunset.Parser.Errors.Semantic;
+
+/// <summary>
+/// Error when an invalid operation is performed on strings.
+/// Only the + operator is allowed for string concatenation.
+/// </summary>
+public class InvalidStringOperationError(BinaryExpression expression) : ISemanticError
+{
+    public string Message =>
+        $"Invalid operation '{expression.Operator}' on strings. Only '+' is allowed for string concatenation.";
+
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken StartToken { get; } = expression.OperatorToken;
+    public IToken? EndToken => null;
+}

--- a/src/Sunset.Parser/Lexing/Lexer.cs
+++ b/src/Sunset.Parser/Lexing/Lexer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Sunset.Parser.Errors;
 using Sunset.Parser.Errors.Syntax;
 using Sunset.Parser.Lexing.Tokens;
@@ -483,7 +483,10 @@ public class Lexer
             Advance();
         }
 
-        return new StringToken(_source[(start + 1) .. _position], TokenType.String, start, _position, _line,
+        // Advance past the closing quote
+        Advance();
+        
+        return new StringToken(_source[(start + 1) .. (_position - 1)], TokenType.String, start, _position, _line,
             _column, _file);
     }
 

--- a/src/Sunset.Parser/Results/StringResult.cs
+++ b/src/Sunset.Parser/Results/StringResult.cs
@@ -1,6 +1,32 @@
-﻿namespace Sunset.Parser.Results;
+using System.Diagnostics;
 
+namespace Sunset.Parser.Results;
+
+/// <summary>
+///     Wrapper around a string that is returned from evaluating an expression.
+/// </summary>
+[DebuggerDisplay("{Result}")]
 public class StringResult(string result) : IResult
 {
     public string Result { get; } = result;
+
+    public override bool Equals(object? obj)
+    {
+        return obj is StringResult other && Result == other.Result;
+    }
+
+    public override int GetHashCode()
+    {
+        return Result.GetHashCode();
+    }
+
+    public static bool operator ==(StringResult left, StringResult right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(StringResult left, StringResult right)
+    {
+        return !(left == right);
+    }
 }

--- a/src/Sunset.Parser/Results/Types/IResultType.cs
+++ b/src/Sunset.Parser/Results/Types/IResultType.cs
@@ -1,4 +1,4 @@
-﻿using Sunset.Parser.BuiltIns;
+using Sunset.Parser.BuiltIns;
 using Sunset.Parser.Parsing.Declarations;
 using Sunset.Quantities.Units;
 
@@ -21,6 +21,7 @@ public interface IResultType
             UnitType leftUnit when right is UnitType rightUnit => Unit.EqualDimensions(leftUnit.Unit, rightUnit.Unit),
             QuantityType => false,
             BooleanType when right is BooleanType => true,
+            StringType when right is StringType => true,
             ListType leftList when right is ListType rightList => AreCompatible(leftList.ElementType, rightList.ElementType),
             ListType => false,
             DictionaryType leftDict when right is DictionaryType rightDict =>

--- a/src/Sunset.Parser/Visitors/Evaluation/Evaluator.cs
+++ b/src/Sunset.Parser/Visitors/Evaluation/Evaluator.cs
@@ -1,4 +1,4 @@
-﻿using Sunset.Parser.Analysis.NameResolution;
+using Sunset.Parser.Analysis.NameResolution;
 using Sunset.Parser.Analysis.ReferenceChecking;
 using Sunset.Parser.Analysis.TypeChecking;
 using Sunset.Parser.BuiltIns;
@@ -147,8 +147,50 @@ public class Evaluator(ErrorLog log) : IScopedVisitor<IResult>
             return ErrorResult;
         }
 
+        // String concatenation: string + string
+        if (leftResult is StringResult leftString && rightResult is StringResult rightString)
+        {
+            if (dest.Operator == TokenType.Plus)
+            {
+                return new StringResult(leftString.Result + rightString.Result);
+            }
+            return ErrorResult;
+        }
+
+        // String concatenation: string + quantity
+        if (leftResult is StringResult leftStr && rightResult is QuantityResult rightQty)
+        {
+            if (dest.Operator == TokenType.Plus)
+            {
+                return new StringResult(leftStr.Result + FormatQuantity(rightQty));
+            }
+            return ErrorResult;
+        }
+
+        // String concatenation: quantity + string
+        if (leftResult is QuantityResult leftQty && rightResult is StringResult rightStr)
+        {
+            if (dest.Operator == TokenType.Plus)
+            {
+                return new StringResult(FormatQuantity(leftQty) + rightStr.Result);
+            }
+            return ErrorResult;
+        }
+
         Log.Error(new OperationError(dest));
         return ErrorResult;
+    }
+
+    /// <summary>
+    /// Formats a quantity result for string concatenation with its display value and units.
+    /// </summary>
+    private static string FormatQuantity(QuantityResult qty)
+    {
+        var quantity = qty.Result;
+        // Use the converted value (in display units) and the unit symbol
+        var value = quantity.ConvertedValue;
+        var unit = quantity.Unit.IsDimensionless ? "" : " " + quantity.Unit;
+        return value + unit;
     }
 
     private IResult Visit(UnaryExpression dest, IScope currentScope)
@@ -384,8 +426,8 @@ public class Evaluator(ErrorLog log) : IScopedVisitor<IResult>
             return ErrorResult;
         }
 
-        // Check for empty list (except for where which can handle empty lists)
-        if (list.Count == 0 && method is not WhereMethod)
+        // Check for empty list (except for where and join which can handle empty lists)
+        if (list.Count == 0 && method is not WhereMethod and not JoinMethod)
         {
             Log.Error(new EmptyListMethodError(call, method.Name));
             return ErrorResult;
@@ -414,6 +456,20 @@ public class Evaluator(ErrorLog log) : IScopedVisitor<IResult>
             }
 
             var result = methodWithExpr.Evaluate(list, expression, scope, EvaluateWithContext);
+            call.SetResult(scope, result);
+            return result;
+        }
+
+        // For methods with string arguments (join)
+        if (method is IListMethodWithStringArgument methodWithStringArg && call.Arguments.Count > 0)
+        {
+            var argResult = Visit(call.Arguments[0].Expression, scope);
+            if (argResult is not StringResult stringResult)
+            {
+                return ErrorResult;
+            }
+
+            var result = methodWithStringArg.Evaluate(list, stringResult.Result);
             call.SetResult(scope, result);
             return result;
         }

--- a/tests/Sunset.Parser.Tests/Integration/StringOperations.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Integration/StringOperations.Tests.cs
@@ -1,0 +1,206 @@
+using Sunset.Parser.Errors;
+using Sunset.Parser.Errors.Semantic;
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Results;
+using Sunset.Parser.Scopes;
+using Sunset.Parser.Visitors.Evaluation;
+using Sunset.Quantities.Units;
+using Environment = Sunset.Parser.Scopes.Environment;
+
+namespace Sunset.Parser.Test.Integration;
+
+[TestFixture]
+public class StringOperationsTests
+{
+    #region String Concatenation Tests
+
+    [Test]
+    public void Analyse_StringPlusString_ConcatenatesStrings()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Message = "hello " + "world"
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Message", new StringResult("hello world"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_StringPlusQuantity_FormatsQuantity()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Length {m} = 100 {m}
+                                               Message = "The length is " + Length
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Message", new StringResult("The length is 100 m"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_QuantityPlusString_FormatsQuantity()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Width {mm} = 50 {mm}
+                                               Message = Width + " is the width"
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Message", new StringResult("50 mm is the width"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_MultipleStringConcatenation_Works()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Part1 = "Hello"
+                                               Part2 = " "
+                                               Part3 = "World"
+                                               Result = Part1 + Part2 + Part3
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Result", new StringResult("Hello World"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_StringWithDimensionlessQuantity_OmitsUnit()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Count = 42
+                                               Message = "The count is " + Count
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Message", new StringResult("The count is 42"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    #endregion
+
+    #region List Join Tests
+
+    [Test]
+    public void Analyse_JoinStringList_JoinsWithSeparator()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Words = ["hello", "world"]
+                                               Sentence = Words.join(", ")
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Sentence", new StringResult("hello, world"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_JoinEmptyList_ReturnsEmptyString()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Words = []
+                                               Sentence = Words.join(", ")
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Sentence", new StringResult(""));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_JoinSingleElement_ReturnsElement()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Words = ["hello"]
+                                               Sentence = Words.join(", ")
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Sentence", new StringResult("hello"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_JoinWithEmptySeparator_ConcatenatesDirectly()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Chars = ["a", "b", "c"]
+                                               Result = Chars.join("")
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Result", new StringResult("abc"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    #endregion
+
+    #region String in Variable Declaration Tests
+
+    [Test]
+    public void Analyse_StringVariable_ValidType()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Name = "Sunset"
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        AssertVariableDeclaration(environment.ChildScopes["$file"], "Name", new StringResult("Sunset"));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    [Test]
+    public void Analyse_StringListVariable_ValidType()
+    {
+        var sourceFile = SourceFile.FromString("""
+                                               Names = ["Alice", "Bob", "Charlie"]
+                                               """);
+        var environment = new Environment(sourceFile);
+        environment.Analyse();
+
+        var fileScope = environment.ChildScopes["$file"];
+        var variable = fileScope.ChildDeclarations["Names"] as VariableDeclaration;
+        var result = variable?.GetResult(fileScope) as ListResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Count, Is.EqualTo(3));
+        Assert.That(result[0], Is.EqualTo(new StringResult("Alice")));
+        Assert.That(result[1], Is.EqualTo(new StringResult("Bob")));
+        Assert.That(result[2], Is.EqualTo(new StringResult("Charlie")));
+        Assert.That(environment.Log.ErrorMessages.Any(), Is.False);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static void AssertVariableDeclaration(IScope scope, string variableName, IResult expectedValue)
+    {
+        if (scope.ChildDeclarations[variableName] is VariableDeclaration variableDeclaration)
+        {
+            var value = variableDeclaration.GetResult(scope);
+
+            Assert.That(value, Is.Not.Null);
+            Assert.That(value, Is.EqualTo(expectedValue));
+        }
+        else
+        {
+            Assert.Fail($"Expected variable {variableName} to be declared.");
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Implements Priority 4 from the ROADMAP: String Operations

### Features Added
- **String concatenation**: `"hello " + "world"`, `"Length: " + 100 {mm}`, `100 {mm} + " long"`
- **List join method**: `["a", "b", "c"].join(", ")` returns `"a, b, c"`

### Bug Fixes
- Fixed lexer bug where closing quote wasn't consumed for string tokens
- Added `StringResult` equality implementation for proper value comparison

### Type System Improvements
- `StringType`, `BooleanType`, and `ListType` are now exempt from unit declaration requirements
- Added `IListMethodWithStringArgument` interface for list methods taking string arguments

### Files Changed
- `src/Sunset.Parser/Lexing/Lexer.cs` - Fix string token parsing
- `src/Sunset.Parser/Results/StringResult.cs` - Add equality implementation
- `src/Sunset.Parser/Results/Types/IResultType.cs` - Add string type compatibility
- `src/Sunset.Parser/Analysis/TypeChecking/TypeChecker.cs` - Add string concatenation type checking
- `src/Sunset.Parser/Visitors/Evaluation/Evaluator.cs` - Add string concatenation evaluation
- `src/Sunset.Parser/BuiltIns/ListMethods/JoinMethod.cs` - New join method
- `src/Sunset.Parser/BuiltIns/ListMethods/ListMethods.cs` - Register join method
- `src/Sunset.Parser/Errors/Semantic/StringErrors.cs` - Add string operation errors
- `tests/Sunset.Parser.Tests/Integration/StringOperations.Tests.cs` - 11 new tests

### Notes
String interpolation (`"Value: {expression}"`) was deferred due to syntax conflict with the `{unit}` notation. Use string concatenation as an alternative.

### Testing
All 11 new string operation tests pass. All existing tests continue to pass.