### PR TITLE
feat: implement pattern matching with 'is' keyword

### DIFF
--- a/docs/user/reference.md
+++ b/docs/user/reference.md
@@ -364,9 +364,9 @@ Result <r> = numerator / denominator
 ### Type Comparison Operators
 
 | Operator | Description | Example |
-|----------|-------------|---------|
+|----------|-------------|-------|
 | `is` | Type equality | `Section is Circle` |
-| `is not` | Type inequality | `Section is not Circle` |
+| `is Type binding` | Type match with binding | `Section is Circle circ` |
 
 ### Operator Precedence
 
@@ -417,6 +417,49 @@ y = 10 if x < 12
 - All branches must evaluate to the same type/units
 - The `otherwise` branch is required
 - Conditions are evaluated sequentially; first true condition wins
+
+### Type Pattern Matching
+
+Use `is` to check element types and optionally bind to a typed variable:
+
+```sunset
+prototype Shape:
+    outputs:
+        return Area {m^2}
+end
+
+define Rectangle as Shape:
+    inputs:
+        Width = 1 {m}
+        Length = 2 {m}
+    outputs:
+        return Area {m^2} = Width * Length
+end
+
+define Circle as Shape:
+    inputs:
+        Radius = 1 {m}
+    outputs:
+        return Area {m^2} = 3.14159 * Radius ^ 2
+end
+
+myShape {Shape} = Rectangle(2 {m}, 3 {m})
+
+// Pattern matching with binding
+area {m^2} = rect.Width * rect.Length if myShape is Rectangle rect
+           = 3.14159 * circ.Radius ^ 2 if myShape is Circle circ
+           = error otherwise
+```
+
+| Syntax | Description |
+|--------|-------------|
+| `expr is Type` | Check if expression matches type |
+| `expr is Type binding` | Check type and bind to variable with that type |
+
+**Rules:**
+- An `otherwise` branch is always required when using pattern matching
+- Binding variables are only in scope within their branch body
+- The binding has the matched type, enabling access to type-specific properties
 
 ---
 

--- a/src/Sunset.Parser/Analysis/NameResolution/PatternBindingScope.cs
+++ b/src/Sunset.Parser/Analysis/NameResolution/PatternBindingScope.cs
@@ -1,0 +1,83 @@
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Scopes;
+using Sunset.Parser.Visitors;
+
+namespace Sunset.Parser.Analysis.NameResolution;
+
+/// <summary>
+/// A scope that introduces a pattern binding variable.
+/// This scope wraps a parent scope and adds a single binding variable
+/// that refers to the matched element in a pattern match expression.
+/// </summary>
+public class PatternBindingScope : IScope
+{
+    /// <summary>
+    /// The parent scope that this binding scope wraps.
+    /// </summary>
+    public IScope? ParentScope { get; init; }
+
+    /// <summary>
+    /// The name of the binding variable.
+    /// </summary>
+    public string BindingName { get; }
+
+    /// <summary>
+    /// The element declaration that the binding refers to.
+    /// </summary>
+    public ElementDeclaration BoundElementType { get; }
+
+    /// <summary>
+    /// The synthetic variable declaration for the binding.
+    /// </summary>
+    private readonly PatternBindingVariable _bindingVariable;
+
+    public PatternBindingScope(IScope parentScope, string bindingName, ElementDeclaration boundElementType)
+    {
+        ParentScope = parentScope;
+        BindingName = bindingName;
+        BoundElementType = boundElementType;
+        _bindingVariable = new PatternBindingVariable(bindingName, this, boundElementType);
+    }
+
+    public string Name => $"$pattern({BindingName})";
+    public string FullPath => $"{ParentScope?.FullPath ?? "$"}.{Name}";
+    public Dictionary<string, IDeclaration> ChildDeclarations { get; } = new();
+    public Dictionary<string, IPassData> PassData { get; } = new();
+
+    public IDeclaration? TryGetDeclaration(string name)
+    {
+        // First check if this is the binding variable
+        if (name == BindingName)
+        {
+            return _bindingVariable;
+        }
+
+        // Otherwise, delegate to the parent scope
+        return ParentScope?.TryGetDeclaration(name);
+    }
+}
+
+/// <summary>
+/// A synthetic variable declaration that represents a pattern binding.
+/// This variable is created during name resolution to represent the 
+/// bound element in a pattern match expression.
+/// </summary>
+public class PatternBindingVariable : IDeclaration
+{
+    public string Name { get; }
+    public IScope? ParentScope { get; init; }
+    public string FullPath => $"{ParentScope?.FullPath ?? "$"}.{Name}";
+    public Dictionary<string, IPassData> PassData { get; } = new();
+
+    /// <summary>
+    /// The element declaration that this binding refers to.
+    /// </summary>
+    public ElementDeclaration BoundElementType { get; }
+
+    public PatternBindingVariable(string name, IScope parentScope, ElementDeclaration boundElementType)
+    {
+        Name = name;
+        ParentScope = parentScope;
+        BoundElementType = boundElementType;
+    }
+}

--- a/src/Sunset.Parser/Errors/Semantic/PatternMatchingErrors.cs
+++ b/src/Sunset.Parser/Errors/Semantic/PatternMatchingErrors.cs
@@ -1,0 +1,37 @@
+using Sunset.Parser.Expressions;
+using Sunset.Parser.Lexing.Tokens;
+
+namespace Sunset.Parser.Errors.Semantic;
+
+/// <summary>
+/// Error when pattern matching is used without an 'otherwise' branch.
+/// </summary>
+public class PatternMatchingRequiresOtherwiseError(IfExpression expression) : ISemanticError
+{
+    public string Message => "Pattern matching requires an 'otherwise' branch.";
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken? StartToken { get; } = expression.Branches.FirstOrDefault()?.Token;
+    public IToken? EndToken => null;
+}
+
+/// <summary>
+/// Error when a type name in a pattern cannot be resolved.
+/// </summary>
+public class PatternTypeNotFoundError(IToken typeToken) : ISemanticError
+{
+    public string Message => $"Type '{typeToken}' not found for pattern matching.";
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken? StartToken { get; } = typeToken;
+    public IToken? EndToken => null;
+}
+
+/// <summary>
+/// Error when the scrutinee of a pattern match is not an element or prototype type.
+/// </summary>
+public class PatternScrutineeNotElementError(IExpression scrutinee, IToken isToken) : ISemanticError
+{
+    public string Message => "Pattern matching can only be used with element or prototype types.";
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken? StartToken { get; } = isToken;
+    public IToken? EndToken => null;
+}

--- a/src/Sunset.Parser/Expressions/IfBranch.cs
+++ b/src/Sunset.Parser/Expressions/IfBranch.cs
@@ -1,4 +1,4 @@
-﻿using Sunset.Parser.Lexing.Tokens;
+using Sunset.Parser.Lexing.Tokens;
 using Sunset.Parser.Visitors;
 
 namespace Sunset.Parser.Expressions;
@@ -6,10 +6,12 @@ namespace Sunset.Parser.Expressions;
 public class IfBranch(
     IExpression body,
     IExpression condition,
-    IToken ifToken) : IBranch
+    IToken ifToken,
+    IsPattern? pattern = null) : IBranch
 {
     /// <summary>
     /// The condition evaluated to determine if this branch is executed.
+    /// For pattern matching branches, this is the scrutinee expression.
     /// </summary>
     public IExpression Condition { get; } = condition;
 
@@ -19,6 +21,17 @@ public class IfBranch(
     /// The token containing the 'if' keyword.
     /// </summary>
     public IToken IfToken { get; } = ifToken;
+
+    /// <summary>
+    /// Optional type pattern for pattern matching (e.g., "is Rectangle rect").
+    /// When set, the Condition represents the scrutinee being matched.
+    /// </summary>
+    public IsPattern? Pattern { get; } = pattern;
+
+    /// <summary>
+    /// Returns true if this branch uses pattern matching.
+    /// </summary>
+    public bool IsPatternMatch => Pattern != null;
 
     public IToken Token => IfToken;
     public Dictionary<string, IPassData> PassData { get; } = [];

--- a/src/Sunset.Parser/Expressions/IsPattern.cs
+++ b/src/Sunset.Parser/Expressions/IsPattern.cs
@@ -1,0 +1,50 @@
+using Sunset.Parser.Lexing.Tokens;
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Visitors;
+
+namespace Sunset.Parser.Expressions;
+
+/// <summary>
+/// Represents a type pattern in an if expression, e.g., "myShape is Rectangle rect".
+/// </summary>
+public class IsPattern : ExpressionBase
+{
+    /// <summary>
+    /// The 'is' keyword token.
+    /// </summary>
+    public IToken IsToken { get; }
+
+    /// <summary>
+    /// The type name being matched against (e.g., "Rectangle").
+    /// </summary>
+    public StringToken TypeNameToken { get; }
+
+    /// <summary>
+    /// Optional binding variable name (e.g., "rect" in "is Rectangle rect").
+    /// If null, no binding is created.
+    /// </summary>
+    public StringToken? BindingNameToken { get; }
+
+    /// <summary>
+    /// The resolved type declaration (PrototypeDeclaration or ElementDeclaration).
+    /// Set during name resolution.
+    /// </summary>
+    private IDeclaration? _resolvedType;
+
+    public IsPattern(IToken isToken, StringToken typeNameToken, StringToken? bindingNameToken = null)
+    {
+        IsToken = isToken;
+        TypeNameToken = typeNameToken;
+        BindingNameToken = bindingNameToken;
+    }
+
+    /// <summary>
+    /// Gets the resolved type declaration.
+    /// </summary>
+    public IDeclaration? GetResolvedType() => _resolvedType;
+
+    /// <summary>
+    /// Sets the resolved type declaration during name resolution.
+    /// </summary>
+    public void SetResolvedType(IDeclaration type) => _resolvedType = type;
+}

--- a/src/Sunset.Parser/Results/Types/IResultType.cs
+++ b/src/Sunset.Parser/Results/Types/IResultType.cs
@@ -13,6 +13,9 @@ public interface IResultType
     {
         // Return false if either type is null - null types are not allowed.
         if (left is null || right is null) return false;
+        
+        // ErrorValueType is compatible with any type (it's a bottom type / sentinel value)
+        if (left is ErrorValueType || right is ErrorValueType) return true;
 
         return left switch
         {

--- a/src/Sunset.Parser/Visitors/Evaluation/PatternBindingEvaluationScope.cs
+++ b/src/Sunset.Parser/Visitors/Evaluation/PatternBindingEvaluationScope.cs
@@ -1,0 +1,76 @@
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Results;
+using Sunset.Parser.Scopes;
+using Sunset.Parser.Visitors;
+
+namespace Sunset.Parser.Visitors.Evaluation;
+
+/// <summary>
+/// A scope used during evaluation that contains a pattern binding variable.
+/// This scope wraps a parent scope and provides access to the bound element instance.
+/// </summary>
+public class PatternBindingEvaluationScope : IScope
+{
+    /// <summary>
+    /// The parent scope that this binding scope wraps.
+    /// </summary>
+    public IScope? ParentScope { get; init; }
+
+    /// <summary>
+    /// The name of the binding variable.
+    /// </summary>
+    public string BindingName { get; }
+
+    /// <summary>
+    /// The element instance result that the binding refers to.
+    /// </summary>
+    public ElementInstanceResult BoundInstance { get; }
+
+    public PatternBindingEvaluationScope(IScope parentScope, string bindingName, ElementInstanceResult boundInstance)
+    {
+        ParentScope = parentScope;
+        BindingName = bindingName;
+        BoundInstance = boundInstance;
+    }
+
+    public string Name => $"$pattern_eval({BindingName})";
+    public string FullPath => $"{ParentScope?.FullPath ?? "$"}.{Name}";
+    public Dictionary<string, IDeclaration> ChildDeclarations => BoundInstance.ChildDeclarations;
+    public Dictionary<string, IPassData> PassData { get; } = new();
+
+    public IDeclaration? TryGetDeclaration(string name)
+    {
+        // The binding name refers to the element instance, which gives access to its properties
+        if (name == BindingName)
+        {
+            // Return a reference that the evaluator can use to access the bound instance
+            return new PatternBindingReference(BindingName, this, BoundInstance);
+        }
+
+        // Otherwise, delegate to the parent scope
+        return ParentScope?.TryGetDeclaration(name);
+    }
+}
+
+/// <summary>
+/// A reference to a pattern binding that can be used during evaluation.
+/// </summary>
+public class PatternBindingReference : IDeclaration
+{
+    public string Name { get; }
+    public IScope? ParentScope { get; init; }
+    public string FullPath => $"{ParentScope?.FullPath ?? "$"}.{Name}";
+    public Dictionary<string, IPassData> PassData { get; } = new();
+
+    /// <summary>
+    /// The element instance that this binding refers to.
+    /// </summary>
+    public ElementInstanceResult BoundInstance { get; }
+
+    public PatternBindingReference(string name, IScope parentScope, ElementInstanceResult boundInstance)
+    {
+        Name = name;
+        ParentScope = parentScope;
+        BoundInstance = boundInstance;
+    }
+}

--- a/tests/Sunset.Parser.Tests/Integration/PatternMatching.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Integration/PatternMatching.Tests.cs
@@ -1,0 +1,538 @@
+using Sunset.Parser.Errors;
+using Sunset.Parser.Errors.Semantic;
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Results;
+using Sunset.Parser.Scopes;
+using Sunset.Parser.Visitors.Debugging;
+using Sunset.Parser.Visitors.Evaluation;
+using Environment = Sunset.Parser.Scopes.Environment;
+
+namespace Sunset.Parser.Test.Integration;
+
+[TestFixture]
+public class PatternMatchingTests
+{
+    /// <summary>
+    /// Gets errors excluding unit declaration warnings which are expected in simple test cases.
+    /// </summary>
+    private static IEnumerable<IOutputMessage> GetSignificantErrors(Environment env)
+    {
+        return env.Log.ErrorMessages
+            .OfType<AttachedOutputMessage>()
+            .Where(m => m.Error is not VariableUnitDeclarationError 
+                     && m.Error is not VariableUnitEvaluationError);
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithRectangle_SelectsCorrectBranch()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                    Length = 2 {m}
+                outputs:
+                    return Area {m^2} = Width * Length
+            end
+
+            define Circle as Shape:
+                inputs:
+                    Radius = 1 {m}
+                outputs:
+                    return Area {m^2} = 3.14159 * Radius ^ 2
+            end
+
+            myShape {Shape} = Rectangle(2 {m}, 3 {m})
+
+            result = 1 if myShape is Rectangle
+                   = 2 if myShape is Circle
+                   = 0 otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        Console.WriteLine("All error messages:");
+        foreach (var msg in env.Log.ErrorMessages)
+        {
+            if (msg is AttachedOutputMessage attached)
+            {
+                Console.WriteLine($"  Error: {attached.Error.GetType().Name}");
+                if (attached.Error is Sunset.Parser.Errors.Syntax.UnexpectedSymbolError syntaxError)
+                    Console.WriteLine($"    Token: '{syntaxError.StartToken}' at line {syntaxError.StartToken.LineStart}");
+            }
+            else
+                Console.WriteLine($"  Message: {msg.GetType().Name}");
+        }
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(1)); // Rectangle branch selected
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithCircle_SelectsCorrectBranch()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                    Length = 2 {m}
+                outputs:
+                    return Area {m^2} = Width * Length
+            end
+
+            define Circle as Shape:
+                inputs:
+                    Radius = 1 {m}
+                outputs:
+                    return Area {m^2} = 3.14159 * Radius ^ 2
+            end
+
+            myShape {Shape} = Circle(2 {m})
+
+            result = 1 if myShape is Rectangle
+                   = 2 if myShape is Circle
+                   = 0 otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(2)); // Circle branch selected
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithBinding_CanAccessElementProperties()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                    Length = 2 {m}
+                outputs:
+                    return Area {m^2} = Width * Length
+            end
+
+            define Circle as Shape:
+                inputs:
+                    Radius = 1 {m}
+                outputs:
+                    return Area {m^2} = 3.14159 * Radius ^ 2
+            end
+
+            myShape {Shape} = Rectangle(2 {m}, 3 {m})
+
+            result {m^2} = rect.Width * rect.Length if myShape is Rectangle rect
+                         = 3.14159 * circ.Radius ^ 2 if myShape is Circle circ
+                         = error otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(6)); // 2 * 3 = 6
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithoutBinding_NoErrors()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                    Length = 2 {m}
+                outputs:
+                    return Area {m^2} = Width * Length
+            end
+
+            myShape {Shape} = Rectangle(2 {m}, 3 {m})
+
+            result = 100 if myShape is Rectangle
+                   = 0 otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithoutOtherwise_LogsError()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                outputs:
+                    return Area {m^2} = Width ^ 2
+            end
+
+            myShape {Shape} = Rectangle(2 {m})
+
+            result = 100 if myShape is Rectangle
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        
+        // Should have an error about missing otherwise
+        Assert.That(env.Log.ErrorMessages.Count, Is.GreaterThan(0));
+        var hasPatternOtherwiseError = env.Log.ErrorMessages
+            .OfType<Sunset.Parser.Errors.AttachedOutputMessage>()
+            .Any(m => m.Error is PatternMatchingRequiresOtherwiseError);
+        Assert.That(hasPatternOtherwiseError, Is.True);
+    }
+
+    [Test]
+    public void Analyse_PrototypePropertyAccessWithoutPattern_LogsError()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                    Length = 2 {m}
+                outputs:
+                    return Area {m^2} = Width * Length
+            end
+
+            myShape {Shape} = Rectangle(2 {m}, 3 {m})
+
+            // This should be an error - Width is not a property of Shape
+            result = myShape.Width
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        
+        // Should have an error about Width not being accessible
+        Assert.That(env.Log.ErrorMessages.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithRegularConditions_NoErrors()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                outputs:
+                    return Area {m^2} = Width ^ 2
+            end
+
+            define Circle as Shape:
+                inputs:
+                    Radius = 1 {m}
+                outputs:
+                    return Area {m^2} = 3.14159 * Radius ^ 2
+            end
+
+            myShape {Shape} = Rectangle(2 {m})
+            x = 10
+
+            // Mix regular conditions with pattern matching
+            result = 1 if x > 20
+                   = 2 if myShape is Rectangle
+                   = 3 otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(2)); // x > 20 is false, myShape is Rectangle is true
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingOtherwiseBranch_SelectsOtherwise()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                outputs:
+                    return Area {m^2} = Width ^ 2
+            end
+
+            define Circle as Shape:
+                inputs:
+                    Radius = 1 {m}
+                outputs:
+                    return Area {m^2} = 3.14159 * Radius ^ 2
+            end
+
+            define Triangle as Shape:
+                inputs:
+                    Base = 1 {m}
+                    Height = 1 {m}
+                outputs:
+                    return Area {m^2} = 0.5 * Base * Height
+            end
+
+            myShape {Shape} = Triangle(2 {m}, 3 {m})
+
+            result = 1 if myShape is Rectangle
+                   = 2 if myShape is Circle
+                   = 0 otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(0)); // Neither Rectangle nor Circle, so otherwise
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithNonPrototype_LogsError()
+    {
+        var source = """
+            x = 5
+
+            // This should be an error - x is not an element/prototype
+            result = 100 if x is Rectangle
+                   = 0 otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        
+        // Should have an error about invalid pattern matching
+        Assert.That(env.Log.ErrorMessages.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void Analyse_PatternBindingShadowsVariable_UsesBindingInBranch()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                    Length = 2 {m}
+                outputs:
+                    return Area {m^2} = Width * Length
+            end
+
+            myShape {Shape} = Rectangle(2 {m}, 3 {m})
+            
+            // 'r' exists as a variable outside
+            r = 999
+
+            // Pattern binding 'r' should shadow the outer 'r' in the branch
+            result {m^2} = r.Width * r.Length if myShape is Rectangle r
+                         = 0 {m^2} otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(6)); // 2 * 3 = 6, using binding not outer r
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingInElement_CorrectResult()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            define Rectangle as Shape:
+                inputs:
+                    Width = 1 {m}
+                    Length = 2 {m}
+                outputs:
+                    return Area {m^2} = Width * Length
+            end
+
+            define Circle as Shape:
+                inputs:
+                    Diameter = 2 {m}
+                outputs:
+                    return Area {m^2} = 3.14159 * (Diameter / 2) ^ 2
+            end
+
+            define AreaCalculator:
+                inputs:
+                    ShapeToCalculate {Shape} = Rectangle()
+                outputs:
+                    return Area {m^2} = rect.Width * rect.Length if ShapeToCalculate is Rectangle rect
+                                      = 3.14159 * (circ.Diameter / 2) ^ 2 if ShapeToCalculate is Circle circ
+                                      = error otherwise
+            end
+
+            RectangleInstance {Rectangle} = Rectangle(2 {m}, 3 {m})
+            CircleInstance {Circle} = Circle(4 {m})
+
+            RectangleCalculator = AreaCalculator(RectangleInstance)
+            CircleCalculator = AreaCalculator(CircleInstance)
+            
+            RectangleArea {m^2} = RectangleCalculator.Area
+            CircleArea {m^2} = CircleCalculator.Area
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        
+        var rectAreaVar = fileScope!.ChildDeclarations["RectangleArea"] as VariableDeclaration;
+        var rectAreaResult = rectAreaVar!.GetResult(fileScope) as QuantityResult;
+        Assert.That(rectAreaResult, Is.Not.Null);
+        Assert.That(rectAreaResult!.Result.BaseValue, Is.EqualTo(6)); // 2 * 3
+
+        var circAreaVar = fileScope!.ChildDeclarations["CircleArea"] as VariableDeclaration;
+        var circAreaResult = circAreaVar!.GetResult(fileScope) as QuantityResult;
+        Assert.That(circAreaResult, Is.Not.Null);
+        Assert.That(circAreaResult!.Result.BaseValue, Is.EqualTo(3.14159 * 4)); // 3.14159 * (4/2)^2 = 3.14159 * 4
+    }
+
+    [Test]
+    public void Analyse_PatternMatchingWithPrototypeInheritance_MatchesBasePrototype()
+    {
+        var source = """
+            prototype Shape:
+                outputs:
+                    return Area {m^2}
+            end
+
+            prototype Polygon as Shape:
+                outputs:
+                    Sides
+            end
+
+            define Triangle as Polygon:
+                inputs:
+                    Base = 1 {m}
+                    Height = 1 {m}
+                outputs:
+                    return Area {m^2} = 0.5 * Base * Height
+                    Sides = 3
+            end
+
+            myShape {Shape} = Triangle(2 {m}, 4 {m})
+
+            // Should match Shape since Triangle implements Polygon which implements Shape
+            result = 1 if myShape is Shape
+                   = 0 otherwise
+            """;
+
+        var env = new Environment(SourceFile.FromString(source));
+        env.Analyse();
+
+        Console.WriteLine(DebugPrinter.Print(env));
+        Assert.That(GetSignificantErrors(env), Is.Empty);
+
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
+        var result = variable!.GetResult(fileScope) as QuantityResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(1)); // Matches Shape
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements pattern matching with the `is` keyword, enabling type-safe access to element-specific properties when working with polymorphic elements typed as prototypes.

## New Features

- **Type checking with `is`**: Check if an element matches a specific type
  ```sunset
  result = 1 if myShape is Rectangle
         = 2 if myShape is Circle
         = 0 otherwise
  ```

- **Pattern binding**: Bind matched elements to access type-specific properties
  ```sunset
  area {m^2} = rect.Width * rect.Length if myShape is Rectangle rect
             = 3.14159 * circ.Radius ^ 2 if myShape is Circle circ
             = error otherwise
  ```

- **Error value compatibility**: The `error` keyword now works as a bottom type in if branches

## Implementation Details

### New Files
- `IsPattern.cs` - AST node for pattern matching syntax
- `PatternBindingScope.cs` / `PatternBindingVariable.cs` - Name resolution for pattern bindings  
- `PatternBindingEvaluationScope.cs` / `PatternBindingReference.cs` - Runtime pattern binding
- `PatternMatchingErrors.cs` - Error types for pattern matching validation
- `PatternMatching.Tests.cs` - 12 comprehensive tests

### Modified Files
- `Parser.cs` - Parse `is Type [binding]` syntax
- `NameResolver.cs` - Resolve pattern bindings and type-specific property access
- `TypeChecker.cs` - Validate pattern matching and require `otherwise` branch
- `Evaluator.cs` - Runtime pattern matching with `MatchesPattern`/`ImplementsPrototype`
- `IResultType.cs` - ErrorValueType compatibility with any type
- `IfBranch.cs` - Added optional `Pattern` property

## Bug Fixes

- Handle positional arguments in element instantiation (e.g., `Rectangle(2 {m}, 3 {m})`)
- Fix multi-line if expression parsing in element outputs
- ErrorValueType now compatible with any type in if branches

## Testing

All 281 parser tests pass, including 12 new pattern matching tests covering:
- Basic type checking (Rectangle, Circle)
- Pattern binding with property access
- Shadowing outer variables with bindings
- Pattern matching inside elements
- Prototype inheritance matching
- Error cases (missing otherwise, non-element scrutinee)

## Documentation

Updated docs for:
- `conditionals.md` - Type Pattern Matching section
- `prototypes.md` - Pattern Matching on Prototypes section
- `reference.md` - Updated conditionals section