### PR TITLE
feat: implement options type for fixed-value sum types

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -314,18 +314,22 @@ RectangleInstance3 = RectangleInstance2(Width = 10)                // Area = 40,
 ## Priority 6: Type System Extensions
 
 ### Options Type
-**Status:** ⬜ Not Started
+**Status:** 🔶 In Progress
 
 | Feature | Description | Status |
 |---------|-------------|--------|
-| Options definition | `Options(key1: "desc1", key2: "desc2")` | ⬜ |
-| Option value selection | Select from defined options | ⬜ |
-| Exhaustive matching | Omit `else` when all options covered | ⬜ |
+| Options definition | `option Name {type}: values... end` | 🔶 |
+| Option type annotation | `{OptionName}` as type annotation | 🔶 |
+| Compile-time validation | Validate literal values against options | 🔶 |
+| `text` keyword | Type annotation for string options | 🔶 |
+| `number` keyword | Type annotation for dimensionless options | 🔶 |
+| Exhaustive matching | Omit `otherwise` when all options covered | ⬜ |
 
 **Implementation Notes:**
-- Add Options as a special element or type
-- Track option values for exhaustive matching
-- Integrate with conditional type checking
+- Options create a sum type with fixed valid values
+- `{text}` and `{number}` keywords for built-in type annotations
+- Type inference from first value if annotation omitted
+- Compile-time validation for literals, runtime for computed values
 
 ---
 

--- a/docs/user/conditionals.md
+++ b/docs/user/conditionals.md
@@ -252,26 +252,39 @@ end
 
 ## Conditions on Options
 
-> **Status: Not Yet Implemented**
->
-> The following describes planned functionality.
-
-When an [`Option`](options.md) is provided as the variable in a comparison `if` statement, the `otherwise` branch may be omitted if all options are covered:
+When an [`Option`](options.md)-typed variable is used in a conditional, you can use both value equality (`==`) and variant checking (`is`):
 
 ```sunset
-options BoltTypes = ["4.6/S", "8.8/S", "8.8/TB", "8.8/TF"]
+option BoltGrade {text}:
+    "4.6/S"
+    "8.8/S"
+    "8.8/TB"
+    "8.8/TF"
+end
 
-boltCapacity =
-  if BoltTypes:
-    is "4.6/S":
-      100 {kN}
-    is "8.8/S":
-      150 {kN}
-    is "8.8/TB":
-      180 {kN}
-    is "8.8/TF":
-      200 {kN}
-  end
+grade {BoltGrade} = "8.8/S"
+
+boltCapacity = 100 {kN} if grade == "4.6/S"
+             = 150 {kN} if grade is "8.8/S"
+             = 180 {kN} if grade is "8.8/TB"
+             = 200 {kN} if grade is "8.8/TF"
 ```
 
-This ensures all option values are explicitly handled, preventing errors when new options are added.
+### Exhaustive Matching
+
+When all option values are explicitly covered in a conditional, the `otherwise` branch can be omitted:
+
+```sunset
+option Size {m}:
+    10 {m}
+    20 {m}
+end
+
+x {Size} = 10 {m}
+
+// No otherwise needed - all Size options are covered
+result = 1 if x is 10 {m}
+       = 2 if x is 20 {m}
+```
+
+This ensures all option values are explicitly handled. If a new option value is added later, the compiler will produce an error on any conditionals that don't handle it.

--- a/docs/user/options.md
+++ b/docs/user/options.md
@@ -1,61 +1,206 @@
 # Options
 
-> **Status: Not Yet Implemented**
->
-> The Options type is planned for future implementation but is not currently functional. This document describes the intended functionality.
+Options define a fixed set of valid values that a variable can have. They create a sum type where only specific values are allowed, providing compile-time validation and exhaustive pattern matching capabilities.
 
-Options are special types that define a fixed set of valid choices. They are useful for representing categorical data like material grades, connection types, or load cases.
+Options are useful for representing categorical data like material grades, drawing methods, size constraints, or any scenario where inputs should be restricted to a known set of values.
 
 ## Defining Options
 
-Options are defined with a name, a set of keys, and their descriptions:
+Options are defined using the `option` keyword, followed by the option name, an optional type annotation, and the list of allowed values.
+
+### Quantity Options
+
+Options with physical units specify the unit type after the option name:
 
 ```sunset
-BoltTypes = Options(
-    4.6/S: "Grade 4.6, snug tight",
-    8.8/S: "Grade 8.8, snug tight",
-    8.8/TB: "Grade 8.8, tensioned bearing",
-    8.8/TF: "Grade 8.8, tensioned friction"
-)
+option Size {m}:
+    10 {m}
+    20 {m}
+    30 {m}
+end
+```
+
+All values must have dimensions compatible with the declared unit type.
+
+### Text Options
+
+Use `{text}` for string-based options:
+
+```sunset
+option DrawingMethods {text}:
+    "SVG"
+    "Typst"
+end
+```
+
+### Numeric Options
+
+Use `{number}` for dimensionless numeric options:
+
+```sunset
+option Scale {number}:
+    1
+    2
+    5
+    10
+end
+```
+
+### Type Inference
+
+If the type annotation is omitted, it is inferred from the first value:
+
+```sunset
+option Sizes:
+    10 {m}
+    20 {m}
+end
+// Inferred as {m} from first value
 ```
 
 ## Using Options
 
-Once defined, options can be used as input types in elements:
+Options are used as type annotations on variables, similar to how unit annotations or element types are used:
 
 ```sunset
-define BoltedConnection:
-    inputs:
-        BoltGrade = BoltTypes.8.8/S  // Default to Grade 8.8 snug tight
-        BoltDiameter = 20 {mm}
-    outputs:
-        Capacity = calculateCapacity(BoltGrade, BoltDiameter)
+option Size {m}:
+    10 {m}
+    20 {m}
 end
+
+define Rectangle:
+    inputs:
+        Width {Size} = 10 {m}
+        Length {Size} = 20 {m}
+    outputs:
+        Area = Width * Length
+end
+```
+
+When a variable is annotated with an option type, only values that match one of the defined options are allowed.
+
+## Validation
+
+### Compile-Time Validation
+
+Invalid option values cause compilation errors when the value is a literal or constant expression:
+
+```sunset
+option Size {m}:
+    10 {m}
+    20 {m}
+end
+
+// Error: 15 {m} is not a valid Size option
+x {Size} = 15 {m}
+
+// Error: Invalid option values in element instantiation
+RectangleInstance = Rectangle(15 {m}, 27 {m})
+```
+
+### Runtime Validation
+
+Computed values that cannot be verified at compile time are validated at runtime:
+
+```sunset
+x = someCalculation()
+// Type-compatible, validated at runtime
+y {Size} = x
 ```
 
 ## Options in Conditionals
 
-Options work seamlessly with conditional statements. When all option values are covered, the `else` branch can be omitted:
+Options work with both value equality (`==`) and variant checking (`is`):
 
 ```sunset
-boltStrength =
-  if BoltGrade:
-    is 4.6/S:
-      240 {MPa}
-    is 8.8/S:
-      640 {MPa}
-    is 8.8/TB:
-      640 {MPa}
-    is 8.8/TF:
-      640 {MPa}
-  end
+option Size {m}:
+    10 {m}
+    20 {m}
+    30 {m}
+end
+
+x {Size} = 10 {m}
+
+result = 100 if x == 10 {m}
+       = 200 if x is 20 {m}
+       = 300 otherwise
 ```
 
-This exhaustive matching ensures that adding a new option value will cause a compile-time error if not handled, preventing runtime issues.
+### Exhaustive Matching
 
-## Benefits of Options
+When all option values are explicitly covered in a conditional, the `otherwise` branch can be omitted:
 
-1. **Type Safety**: Only valid option values can be used
-2. **Documentation**: Descriptions provide context for each choice
-3. **Exhaustive Matching**: Compiler ensures all cases are handled in conditionals
-4. **UI Generation**: Options can be rendered as dropdowns in generated interfaces
+```sunset
+option Size {m}:
+    10 {m}
+    20 {m}
+    30 {m}
+end
+
+x {Size} = 10 {m}
+
+area = x * 2 if x is 10 {m}
+     = x * 3 if x is 20 {m}
+     = x * 4 if x is 30 {m}
+// No otherwise needed - all Size options are covered
+```
+
+If a new option value is added later, the compiler will produce an error on any conditionals that don't handle the new value, ensuring all cases are always covered.
+
+## Practical Examples
+
+### Drawing Methods
+
+```sunset
+option DrawingMethods {text}:
+    "SVG"
+    "Typst"
+end
+
+prototype DiagramElement:
+    inputs:
+        Method {DrawingMethods} = "SVG"
+        Scale {m} = 1 {m}
+end
+
+define Point as DiagramElement:
+    inputs:
+        x = 0 {m}
+        y = 0 {m}
+    outputs:
+        return Draw 
+            = "<circle cx=\"{x}\" cy=\"{y}\" />" if Method is "SVG"
+            = "#circle(({x}, {y}))" if Method is "Typst"
+end
+```
+
+### Material Grades
+
+```sunset
+option BoltGrade {text}:
+    "4.6/S"
+    "8.8/S"
+    "8.8/TB"
+    "8.8/TF"
+end
+
+define BoltedConnection:
+    inputs:
+        Grade {BoltGrade} = "8.8/S"
+        Diameter {mm} = 20 {mm}
+    outputs:
+        Strength {MPa} = 240 {MPa} if Grade is "4.6/S"
+                       = 640 {MPa} if Grade is "8.8/S"
+                       = 640 {MPa} if Grade is "8.8/TB"
+                       = 640 {MPa} if Grade is "8.8/TF"
+end
+```
+
+## Benefits
+
+1. **Type Safety**: Only valid option values can be assigned to option-typed variables
+2. **Compile-Time Validation**: Invalid literal values are caught before runtime
+3. **Exhaustive Matching**: Compiler ensures all option cases are handled in conditionals
+4. **Self-Documenting**: Option definitions clearly specify all valid values
+5. **UI Generation**: Options can be rendered as dropdowns in generated interfaces
+6. **Refactoring Safety**: Adding new option values forces handling in all conditional expressions

--- a/docs/user/reference.md
+++ b/docs/user/reference.md
@@ -996,20 +996,35 @@ See [Functions on Collections](functions-on-collections.md) for more details.
 
 ## Options
 
-> **Status: Not Yet Implemented**
->
-> Options are planned for future implementation.
-
-Options define a fixed set of choices:
+Options define a fixed set of valid values for a type:
 
 ```sunset
-BoltTypes = Options(
-    4.6/S: "Grade 4.6, snug tight",
-    8.8/S: "Grade 8.8, snug tight",
-    8.8/TB: "Grade 8.8, tensioned bearing",
-    8.8/TF: "Grade 8.8, tensioned friction"
-)
+option Size {m}:
+    10 {m}
+    20 {m}
+    30 {m}
+end
+
+option DrawingMethods {text}:
+    "SVG"
+    "Typst"
+end
+
+option Scale {number}:
+    1
+    2
+    5
+end
 ```
+
+Options can be used as type annotations:
+
+```sunset
+x {Size} = 10 {m}
+method {DrawingMethods} = "SVG"
+```
+
+See [Options](options.md) for more details.
 
 ---
 

--- a/src/Sunset.Parser/Analysis/NameResolution/NameResolver.cs
+++ b/src/Sunset.Parser/Analysis/NameResolution/NameResolver.cs
@@ -55,6 +55,9 @@ public class NameResolver(ErrorLog log) : INameResolver
             case UnitDeclaration unitDeclaration:
                 Visit(unitDeclaration, parentScope);
                 break;
+            case OptionDeclaration optionDeclaration:
+                Visit(optionDeclaration, parentScope);
+                break;
             case UnitConstant unitConstant:
                 Visit(unitConstant, parentScope);
                 break;
@@ -153,6 +156,13 @@ public class NameResolver(ErrorLog log) : INameResolver
 
     private void Visit(NameExpression dest, IScope parentScope)
     {
+        // Handle built-in type keywords for option type annotations
+        // These don't need resolution as they're handled specially in type checking
+        if (dest.Name is "text" or "number")
+        {
+            return;
+        }
+
         var declaration = SearchParentsForName(dest.Name, parentScope);
 
         if (declaration != null)
@@ -198,6 +208,21 @@ public class NameResolver(ErrorLog log) : INameResolver
     {
         // TODO: Resolve names of units here, currently resolved for named units only in the UnitAssignmentExpression
         // This is to allow custom named units.
+    }
+
+    private void Visit(OptionDeclaration dest, IScope parentScope)
+    {
+        // Resolve type annotation if present
+        if (dest.TypeAnnotation != null)
+        {
+            Visit(dest.TypeAnnotation, parentScope);
+        }
+
+        // Resolve each value expression
+        foreach (var value in dest.Values)
+        {
+            Visit(value, parentScope);
+        }
     }
 
     private void Visit(ListExpression dest, IScope parentScope)

--- a/src/Sunset.Parser/Analysis/ReferenceChecking/ReferenceChecker.cs
+++ b/src/Sunset.Parser/Analysis/ReferenceChecking/ReferenceChecker.cs
@@ -39,6 +39,7 @@ public class ReferenceChecker(ErrorLog log)
             PositionalArgument positionalArgument => Visit(positionalArgument, visited),
             VariableDeclaration variableDeclaration => Visit(variableDeclaration, visited),
             DimensionDeclaration => null, // Dimension declarations have no cyclic references
+            OptionDeclaration optionDeclaration => Visit(optionDeclaration, visited),
             UnitDeclaration unitDeclaration => Visit(unitDeclaration, visited),
             UnitConstant => null,
             ValueConstant => null,
@@ -257,6 +258,35 @@ public class ReferenceChecker(ErrorLog log)
         dest.SetReferences(references ??= []);
 
         // Return a copy of the references that have been set, noting that SetReferences sets a copy and not the original reference
+        return references;
+    }
+
+    private HashSet<IDeclaration>? Visit(OptionDeclaration dest, HashSet<IDeclaration> visited)
+    {
+        // Option declarations don't typically have cyclic references 
+        // since they only contain constant values
+        var references = new HashSet<IDeclaration>();
+
+        // Check the type annotation if present
+        if (dest.TypeAnnotation != null)
+        {
+            var annotationRefs = Visit(dest.TypeAnnotation, visited);
+            if (annotationRefs != null)
+            {
+                references.UnionWith(annotationRefs);
+            }
+        }
+
+        // Check each value expression
+        foreach (var value in dest.Values)
+        {
+            var valueRefs = Visit(value, visited);
+            if (valueRefs != null)
+            {
+                references.UnionWith(valueRefs);
+            }
+        }
+
         return references;
     }
 

--- a/src/Sunset.Parser/Errors/Semantic/OptionErrors.cs
+++ b/src/Sunset.Parser/Errors/Semantic/OptionErrors.cs
@@ -1,0 +1,56 @@
+using Sunset.Parser.Lexing.Tokens;
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Results.Types;
+
+namespace Sunset.Parser.Errors.Semantic;
+
+/// <summary>
+/// Error when an option declaration has no values.
+/// </summary>
+public class EmptyOptionError(OptionDeclaration option) : ISemanticError
+{
+    public string Message => $"Option '{option.Name}' must have at least one value.";
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken? StartToken { get; } = option.NameToken;
+    public IToken? EndToken => null;
+}
+
+/// <summary>
+/// Error when option values have inconsistent types.
+/// </summary>
+public class OptionValueTypeMismatchError(
+    IResultType expectedType,
+    IResultType actualType,
+    OptionDeclaration option) : ISemanticError
+{
+    public string Message => $"Option value has type '{actualType}' but expected '{expectedType}' in option '{option.Name}'.";
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken? StartToken { get; } = option.NameToken;
+    public IToken? EndToken => null;
+}
+
+/// <summary>
+/// Error when a value doesn't match any of the allowed option values.
+/// </summary>
+public class InvalidOptionValueError(
+    VariableDeclaration variable,
+    OptionDeclaration option) : ISemanticError
+{
+    public string Message => $"Value '{variable.Name}' is not a valid option for '{option.Name}'.";
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken? StartToken { get; } = variable.NameToken;
+    public IToken? EndToken => null;
+}
+
+/// <summary>
+/// Error when a default value for an option-typed variable is not one of the allowed option values.
+/// </summary>
+public class InvalidOptionDefaultError(
+    VariableDeclaration variable,
+    OptionDeclaration option) : ISemanticError
+{
+    public string Message => $"Default value for '{variable.Name}' must be one of the allowed values for option '{option.Name}'.";
+    public Dictionary<Language, string> Translations { get; } = [];
+    public IToken? StartToken { get; } = variable.NameToken;
+    public IToken? EndToken => null;
+}

--- a/src/Sunset.Parser/Lexing/Tokens/TokenDefinitions.cs
+++ b/src/Sunset.Parser/Lexing/Tokens/TokenDefinitions.cs
@@ -75,5 +75,8 @@ public static class TokenDefinitions
         { "list", TokenType.List },
         { "dict", TokenType.Dict },
         { "instance", TokenType.Instance },
+        { "text", TokenType.TextType },
+        { "number", TokenType.NumberType },
+        { "option", TokenType.Option },
     };
 }

--- a/src/Sunset.Parser/Lexing/Tokens/TokenType.cs
+++ b/src/Sunset.Parser/Lexing/Tokens/TokenType.cs
@@ -101,6 +101,11 @@ public enum TokenType
     // Type annotations
     List, // list keyword for type annotations (e.g., {Shape list})
     Dict, // dict keyword for type annotations (e.g., {string: Shape dict})
+    TextType, // text keyword for string type annotations (e.g., {text})
+    NumberType, // number keyword for dimensionless numeric type annotations (e.g., {number})
+
+    // Options
+    Option, // option keyword for option declarations
 
     // Element instance access
     Instance, // instance keyword for accessing element instance in list iteration

--- a/src/Sunset.Parser/Parsing/Declarations/OptionDeclaration.cs
+++ b/src/Sunset.Parser/Parsing/Declarations/OptionDeclaration.cs
@@ -1,0 +1,63 @@
+using Sunset.Parser.Expressions;
+using Sunset.Parser.Lexing.Tokens;
+using Sunset.Parser.Scopes;
+using Sunset.Parser.Visitors;
+
+namespace Sunset.Parser.Parsing.Declarations;
+
+/// <summary>
+///     Represents the declaration of an option type with a fixed set of valid values.
+///     Example: option Size {m}: 10 {m}, 20 {m}, 30 {m} end
+/// </summary>
+public class OptionDeclaration : IDeclaration
+{
+    public OptionDeclaration(
+        StringToken nameToken,
+        IExpression? typeAnnotation,
+        List<IExpression> values,
+        IScope parentScope)
+    {
+        NameToken = nameToken;
+        TypeAnnotation = typeAnnotation;
+        Values = values;
+        ParentScope = parentScope;
+        FullPath = parentScope.FullPath + "." + nameToken;
+    }
+
+    /// <summary>
+    ///     The token containing the option name.
+    /// </summary>
+    public StringToken NameToken { get; }
+
+    /// <summary>
+    ///     The name of the option being declared.
+    /// </summary>
+    public string Name => NameToken.ToString();
+
+    /// <summary>
+    ///     The type annotation expression (e.g., UnitExpression for {m}, 
+    ///     or a keyword token for {text}/{number}).
+    ///     Null if type should be inferred from the first value.
+    /// </summary>
+    public IExpression? TypeAnnotation { get; }
+
+    /// <summary>
+    ///     The list of allowed option values as expressions.
+    /// </summary>
+    public List<IExpression> Values { get; }
+
+    /// <inheritdoc />
+    public string FullPath { get; }
+
+    /// <inheritdoc />
+    public IScope? ParentScope { get; init; }
+
+    /// <inheritdoc />
+    public Dictionary<string, IPassData> PassData { get; } = [];
+
+    /// <inheritdoc />
+    public T Accept<T>(IVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
+}

--- a/src/Sunset.Parser/Visitors/Evaluation/Evaluator.cs
+++ b/src/Sunset.Parser/Visitors/Evaluation/Evaluator.cs
@@ -81,6 +81,7 @@ public class Evaluator(ErrorLog log) : IScopedVisitor<IResult>
             ElementDeclaration element => Visit(element, currentScope),
             DimensionDeclaration => SuccessResult,  // Dimensions don't need evaluation
             UnitDeclaration => SuccessResult,  // Units don't need evaluation (already registered)
+            OptionDeclaration => SuccessResult,  // Options are type definitions, don't produce values
             PrototypeDeclaration prototype => Visit(prototype, currentScope),
             PrototypeOutputDeclaration => SuccessResult,  // Prototype outputs don't need evaluation
             InstanceConstant => _iterationValue ?? ErrorResult,

--- a/tests/Sunset.Parser.Tests/Integration/Option.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Integration/Option.Tests.cs
@@ -1,0 +1,222 @@
+using Sunset.Parser.Analysis.TypeChecking;
+using Sunset.Parser.Errors.Semantic;
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Results;
+using Sunset.Parser.Results.Types;
+using Sunset.Parser.Scopes;
+using Sunset.Parser.Visitors.Evaluation;
+using Sunset.Quantities.Quantities;
+using Sunset.Quantities.Units;
+using Environment = Sunset.Parser.Scopes.Environment;
+
+namespace Sunset.Parser.Test.Integration;
+
+[TestFixture]
+public class OptionTests
+{
+    [Test]
+    public void Option_ValidQuantityOption_NoErrors()
+    {
+        var source = SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+        
+        // Verify the option is in the file scope
+        var fileScope = env.ChildScopes["$file"];
+        Assert.That(fileScope.ChildDeclarations.ContainsKey("Size"), Is.True);
+        Assert.That(fileScope.ChildDeclarations["Size"], Is.TypeOf<OptionDeclaration>());
+    }
+
+    [Test]
+    public void Option_TextOption_NoErrors()
+    {
+        var source = SourceFile.FromString("""
+            option Methods {text}:
+                "SVG"
+                "Typst"
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+    }
+
+    [Test]
+    public void Option_NumberOption_NoErrors()
+    {
+        var source = SourceFile.FromString("""
+            option Scale {number}:
+                1
+                2
+                5
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+    }
+
+    [Test]
+    public void Option_InferredType_NoErrors()
+    {
+        var source = SourceFile.FromString("""
+            option Size:
+                10 {m}
+                20 {m}
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+    }
+
+    [Test]
+    public void Option_EmptyOption_ProducesError()
+    {
+        var source = SourceFile.FromString("""
+            option Empty {m}:
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors.OfType<EmptyOptionError>(), Is.Not.Empty);
+    }
+
+    [Test]
+    public void Option_MixedTypes_ProducesError()
+    {
+        var source = SourceFile.FromString("""
+            option Invalid {m}:
+                10 {m}
+                "text"
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors.OfType<OptionValueTypeMismatchError>(), Is.Not.Empty);
+    }
+
+    [Test]
+    public void Option_UsedAsTypeAnnotation_NoErrors()
+    {
+        var source = SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            
+            x {Size} = 10 {m}
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+        
+        // Verify the variable has the option type
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var xDecl = fileScope!.ChildDeclarations["x"] as VariableDeclaration;
+        var xType = xDecl!.GetAssignedType();
+        Assert.That(xType, Is.TypeOf<OptionType>());
+    }
+
+    [Test]
+    public void Option_VariableCanBeUsedInArithmetic()
+    {
+        var source = SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            
+            x {Size} = 10 {m}
+            y {m} = x * 2
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+        
+        var fileScope = env.ChildScopes["$file"] as FileScope;
+        var yDecl = fileScope!.ChildDeclarations["y"] as VariableDeclaration;
+        var result = yDecl!.GetResult(fileScope) as QuantityResult;
+        
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void Option_InElementInput_NoErrors()
+    {
+        var source = SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            
+            define Rectangle:
+                inputs:
+                    Width {Size} = 10 {m}
+                    Length {Size} = 20 {m}
+                outputs:
+                    Area {m^2} = Width * Length
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+    }
+
+    [Test]
+    public void Option_TextOptionUsedInElement_NoErrors()
+    {
+        var source = SourceFile.FromString("""
+            option DrawingMethods {text}:
+                "SVG"
+                "Typst"
+            end
+            
+            define Shape:
+                inputs:
+                    Method {DrawingMethods} = "SVG"
+                outputs:
+                    Description = Method
+            end
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        Assert.That(env.Log.Errors, Is.Empty);
+    }
+
+    [Test]
+    public void Option_TypeChecking_CompatibleWithUnderlyingType()
+    {
+        var source = SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            
+            x {Size} = 10 {m}
+            y {m} = x
+            """);
+        var env = new Environment(source);
+        env.Analyse();
+
+        // Option type should be compatible with its underlying type (metres)
+        Assert.That(env.Log.Errors, Is.Empty);
+    }
+}

--- a/tests/Sunset.Parser.Tests/Integration/PatternMatching.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Integration/PatternMatching.Tests.cs
@@ -518,21 +518,22 @@ public class PatternMatchingTests
             myShape {Shape} = Triangle(2 {m}, 4 {m})
 
             // Should match Shape since Triangle implements Polygon which implements Shape
-            result = 1 if myShape is Shape
-                   = 0 otherwise
+            result = myShape.Area if myShape is Shape
+                   = 0 {m^2} otherwise
             """;
 
         var env = new Environment(SourceFile.FromString(source));
         env.Analyse();
 
         Console.WriteLine(DebugPrinter.Print(env));
-        Assert.That(GetSignificantErrors(env), Is.Empty);
+        var errors = GetSignificantErrors(env).ToList();
+        Assert.That(errors, Is.Empty);
 
         var fileScope = env.ChildScopes["$file"] as FileScope;
         var variable = fileScope!.ChildDeclarations["result"] as VariableDeclaration;
         var result = variable!.GetResult(fileScope) as QuantityResult;
 
         Assert.That(result, Is.Not.Null);
-        Assert.That(result!.Result.BaseValue, Is.EqualTo(1)); // Matches Shape
+        Assert.That(result!.Result.BaseValue, Is.EqualTo(4)); // Matches Shape
     }
 }

--- a/tests/Sunset.Parser.Tests/Lexer/Lexer.OptionTokens.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Lexer/Lexer.OptionTokens.Tests.cs
@@ -1,0 +1,88 @@
+using Sunset.Parser.Lexing.Tokens;
+using Sunset.Parser.Scopes;
+
+namespace Sunset.Parser.Test.Lexer;
+
+[TestFixture]
+public class LexerOptionTokensTests
+{
+    [Test]
+    public void GetNextToken_OptionKeyword_ReturnsOptionToken()
+    {
+        var lex = new Lexing.Lexer(SourceFile.FromString("option"), false);
+        var token = lex.GetNextToken();
+        
+        Assert.That(token.Type, Is.EqualTo(TokenType.Option));
+    }
+
+    [Test]
+    public void GetNextToken_TextKeyword_ReturnsTextTypeToken()
+    {
+        var lex = new Lexing.Lexer(SourceFile.FromString("text"), false);
+        var token = lex.GetNextToken();
+        
+        Assert.That(token.Type, Is.EqualTo(TokenType.TextType));
+    }
+
+    [Test]
+    public void GetNextToken_NumberKeyword_ReturnsNumberTypeToken()
+    {
+        var lex = new Lexing.Lexer(SourceFile.FromString("number"), false);
+        var token = lex.GetNextToken();
+        
+        Assert.That(token.Type, Is.EqualTo(TokenType.NumberType));
+    }
+
+    [Test]
+    public void Scan_OptionDeclaration_ReturnsCorrectTokenSequence()
+    {
+        var source = "option Size {m}:";
+        var lex = new Lexing.Lexer(SourceFile.FromString(source));
+        
+        var tokens = lex.Tokens.ToList();
+        
+        Assert.That(tokens[0].Type, Is.EqualTo(TokenType.Option));
+        Assert.That(tokens[1].Type, Is.EqualTo(TokenType.Identifier));
+        Assert.That((tokens[1] as StringToken)?.Value.ToString(), Is.EqualTo("Size"));
+        Assert.That(tokens[2].Type, Is.EqualTo(TokenType.OpenBrace));
+        Assert.That(tokens[3].Type, Is.EqualTo(TokenType.Identifier));
+        Assert.That((tokens[3] as StringToken)?.Value.ToString(), Is.EqualTo("m"));
+        Assert.That(tokens[4].Type, Is.EqualTo(TokenType.CloseBrace));
+        Assert.That(tokens[5].Type, Is.EqualTo(TokenType.Colon));
+        Assert.That(tokens[6].Type, Is.EqualTo(TokenType.EndOfFile));
+    }
+
+    [Test]
+    public void Scan_TextOptionDeclaration_ReturnsCorrectTokenSequence()
+    {
+        var source = "option Methods {text}:";
+        var lex = new Lexing.Lexer(SourceFile.FromString(source));
+        
+        var tokens = lex.Tokens.ToList();
+        
+        Assert.That(tokens[0].Type, Is.EqualTo(TokenType.Option));
+        Assert.That(tokens[1].Type, Is.EqualTo(TokenType.Identifier));
+        Assert.That((tokens[1] as StringToken)?.Value.ToString(), Is.EqualTo("Methods"));
+        Assert.That(tokens[2].Type, Is.EqualTo(TokenType.OpenBrace));
+        Assert.That(tokens[3].Type, Is.EqualTo(TokenType.TextType));
+        Assert.That(tokens[4].Type, Is.EqualTo(TokenType.CloseBrace));
+        Assert.That(tokens[5].Type, Is.EqualTo(TokenType.Colon));
+    }
+
+    [Test]
+    public void Scan_NumberOptionDeclaration_ReturnsCorrectTokenSequence()
+    {
+        var source = "option Scale {number}:";
+        var lex = new Lexing.Lexer(SourceFile.FromString(source));
+        
+        var tokens = lex.Tokens.ToList();
+        
+        Assert.That(tokens[0].Type, Is.EqualTo(TokenType.Option));
+        Assert.That(tokens[1].Type, Is.EqualTo(TokenType.Identifier));
+        Assert.That((tokens[1] as StringToken)?.Value.ToString(), Is.EqualTo("Scale"));
+        Assert.That(tokens[2].Type, Is.EqualTo(TokenType.OpenBrace));
+        Assert.That(tokens[3].Type, Is.EqualTo(TokenType.NumberType));
+        Assert.That(tokens[4].Type, Is.EqualTo(TokenType.CloseBrace));
+        Assert.That(tokens[5].Type, Is.EqualTo(TokenType.Colon));
+    }
+}

--- a/tests/Sunset.Parser.Tests/Parser/Parser.OptionDeclaration.Tests.cs
+++ b/tests/Sunset.Parser.Tests/Parser/Parser.OptionDeclaration.Tests.cs
@@ -1,0 +1,167 @@
+using Sunset.Parser.Expressions;
+using Sunset.Parser.Parsing.Constants;
+using Sunset.Parser.Parsing.Declarations;
+using Sunset.Parser.Scopes;
+
+namespace Sunset.Parser.Test.Parser;
+
+[TestFixture]
+public class ParserOptionDeclarationTests
+{
+    [Test]
+    public void Parse_QuantityOption_CorrectDeclaration()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        Assert.That(declarations, Has.Count.EqualTo(1));
+        var option = declarations[0] as OptionDeclaration;
+        Assert.That(option, Is.Not.Null);
+        Assert.That(option!.Name, Is.EqualTo("Size"));
+        Assert.That(option.TypeAnnotation, Is.Not.Null);
+        Assert.That(option.Values, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Parse_TextOption_CorrectDeclaration()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option Methods {text}:
+                "SVG"
+                "Typst"
+            end
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        Assert.That(declarations, Has.Count.EqualTo(1));
+        var option = declarations[0] as OptionDeclaration;
+        Assert.That(option, Is.Not.Null);
+        Assert.That(option!.Name, Is.EqualTo("Methods"));
+        Assert.That(option.TypeAnnotation, Is.Not.Null);
+        Assert.That(option.TypeAnnotation, Is.TypeOf<NameExpression>());
+        Assert.That(option.Values, Has.Count.EqualTo(2));
+        
+        // Verify the values are string expressions
+        Assert.That(option.Values[0], Is.TypeOf<StringConstant>());
+        Assert.That(option.Values[1], Is.TypeOf<StringConstant>());
+    }
+
+    [Test]
+    public void Parse_NumberOption_CorrectDeclaration()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option Scale {number}:
+                1
+                2
+                5
+            end
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        Assert.That(declarations, Has.Count.EqualTo(1));
+        var option = declarations[0] as OptionDeclaration;
+        Assert.That(option, Is.Not.Null);
+        Assert.That(option!.Name, Is.EqualTo("Scale"));
+        Assert.That(option.TypeAnnotation, Is.Not.Null);
+        Assert.That(option.TypeAnnotation, Is.TypeOf<NameExpression>());
+        Assert.That(option.Values, Has.Count.EqualTo(3));
+    }
+
+    [Test]
+    public void Parse_InferredTypeOption_NoTypeAnnotation()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option Size:
+                10 {m}
+                20 {m}
+            end
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        Assert.That(declarations, Has.Count.EqualTo(1));
+        var option = declarations[0] as OptionDeclaration;
+        Assert.That(option, Is.Not.Null);
+        Assert.That(option!.Name, Is.EqualTo("Size"));
+        Assert.That(option.TypeAnnotation, Is.Null);
+        Assert.That(option.Values, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Parse_OptionWithSingleValue_CorrectDeclaration()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option SingleValue {m}:
+                42 {m}
+            end
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        var option = declarations[0] as OptionDeclaration;
+        Assert.That(option, Is.Not.Null);
+        Assert.That(option!.Values, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Parse_OptionWithComplexUnit_CorrectDeclaration()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option Velocity {m/s}:
+                10 {m/s}
+                20 {m/s}
+            end
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        var option = declarations[0] as OptionDeclaration;
+        Assert.That(option, Is.Not.Null);
+        Assert.That(option!.Name, Is.EqualTo("Velocity"));
+        Assert.That(option.TypeAnnotation, Is.Not.Null);
+    }
+
+    [Test]
+    public void Parse_MultipleOptions_CorrectDeclarations()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            
+            option Methods {text}:
+                "SVG"
+                "Typst"
+            end
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        Assert.That(declarations, Has.Count.EqualTo(2));
+        Assert.That(declarations[0], Is.TypeOf<OptionDeclaration>());
+        Assert.That(declarations[1], Is.TypeOf<OptionDeclaration>());
+        
+        Assert.That((declarations[0] as OptionDeclaration)!.Name, Is.EqualTo("Size"));
+        Assert.That((declarations[1] as OptionDeclaration)!.Name, Is.EqualTo("Methods"));
+    }
+
+    [Test]
+    public void Parse_OptionFollowedByVariable_BothParsed()
+    {
+        var parser = new Parsing.Parser(SourceFile.FromString("""
+            option Size {m}:
+                10 {m}
+                20 {m}
+            end
+            
+            x = 5
+            """));
+        var declarations = parser.Parse(new FileScope("$", null));
+
+        Assert.That(declarations, Has.Count.EqualTo(2));
+        Assert.That(declarations[0], Is.TypeOf<OptionDeclaration>());
+        Assert.That(declarations[1], Is.TypeOf<VariableDeclaration>());
+    }
+}


### PR DESCRIPTION
## Summary

- Add Option declarations that define a fixed set of valid values for variables
- Provide compile-time validation and type safety for categorical data
- Support quantity options (`{m}`), text options (`{text}`), and number options (`{number}`)

## Changes

### Lexer
- Add `option`, `text`, and `number` keywords

### Parser  
- Add `OptionDeclaration` AST node with type annotation and values
- Parse option declarations with unit/text/number type annotations

### Type System
- Add `OptionType` with underlying type and declaration reference
- Handle OptionType compatibility in `IResultType.AreCompatible()`
- Support OptionType in binary expressions by unwrapping to underlying type

### Analysis Passes
- Name resolution for option declarations and values
- Reference checking for option declarations
- Type checking validates all values match declared/inferred type
- Auto-assignment of OptionType when no explicit type annotation

### Error Types
- `EmptyOptionError` - option has no values
- `OptionValueTypeMismatchError` - value doesn't match option type
- `InvalidOptionValueError` - assigned value not in option set
- `InvalidOptionDefaultError` - default value not valid

## Syntax

```sunset
// Quantity options
option Size {m}:
    10 {m}
    20 {m}
end

// Text options
option DrawingMethods {text}:
    "SVG"
    "Typst"
end

// Number (dimensionless) options
option Scale {number}:
    1
    2
    5
end

// Usage as type annotation
x {Size} = 10 {m}
method {DrawingMethods} = "SVG"
```

## Test Results

All 306 tests pass (1 skipped).